### PR TITLE
Add slice plotting functionality

### DIFF
--- a/examples/amr_slices.py
+++ b/examples/amr_slices.py
@@ -1,0 +1,23 @@
+import yt
+import yt_idv
+
+from yt_idv.scene_components.mesh import MeshRendering
+from yt_idv.scene_data.mesh import SliceData
+
+ds = yt.load_sample("IsolatedGalaxy")
+
+# add the volume rendering to the scene
+rc = yt_idv.render_context(height=800, width=800, gui=True)
+sg = rc.add_scene(ds, "density", no_ghost=True)
+
+# create a slice and generate the slice-mesh object
+slc = ds.slice(0, 0.5)
+sd = SliceData(data_source=slc)
+sd.add_data(("gas", "density"))
+
+# initialize the MeshRendering and add to the scene
+mr = MeshRendering(data=sd, cmap_log=True)
+rc.scene.data_objects.append(sd)
+rc.scene.components.append(mr)
+
+rc.run()

--- a/examples/amr_slices_composites.py
+++ b/examples/amr_slices_composites.py
@@ -1,0 +1,34 @@
+import yt
+import yt_idv
+
+from yt_idv.scene_components.mesh import MeshRendering
+from yt_idv.scene_data.mesh import SliceData, SliceComposite
+
+ds = yt.load_sample("IsolatedGalaxy")
+
+# add the volume rendering to the scene
+rc = yt_idv.render_context(height=800, width=800, gui=True)
+sg = rc.add_scene(ds, "density", no_ghost=True)
+
+# create a slice and generate the slice-mesh object
+slc = ds.slice(0, 0.5)
+sd = SliceData(data_source=slc)
+sd.add_data(("gas", "density"))
+
+# create a second slice and generate the slice-mesh object
+slc2 = ds.slice(1, 0.4)
+sd2 = SliceData(data_source=slc2)
+sd2.add_data(("gas", "density"))
+
+# combine the slices into a composite:
+composite = SliceComposite()
+composite.add_data([sd, sd2])
+
+# initialize the MeshRendering and add to the scene
+mr = MeshRendering(data=composite, cmap_log=True)
+rc.scene.data_objects.append(composite)
+rc.scene.components.append(mr)
+
+rc.run()
+
+

--- a/yt_idv/scene_data/mesh.py
+++ b/yt_idv/scene_data/mesh.py
@@ -2,7 +2,6 @@ import numpy as np
 import traitlets
 from yt.data_objects.data_containers import YTDataContainer
 from yt.utilities.lib.mesh_triangulation import triangulate_mesh
-from yt import load_unstructured_mesh
 from yt_idv.opengl_support import Texture3D, VertexArray, VertexAttribute
 from yt_idv.scene_data.base_data import SceneData
 
@@ -62,11 +61,40 @@ class MeshData(SceneData):
 
 
 class SliceData(MeshData):
+    # a class to construct a mesh source from an axis-normal slice.
     name = "slice"
     _frb_args = None
     _mesh_ds = None
 
-    def assemble(self, xe, ye, ze, nx, ny, nz, frb_cell_center_vals):
+    def add_data(self, field, width=1., resolution=(400, 400), center=None, height=None, periodic=False):
+        """
+        adds the slice data for a field. This will generate a fixed resolution buffer
+        of the slice and then construct an unstructured mesh representing the plane.
+        Use the keyword arguments to control the FixedResolutionBuffer.
+
+
+        Parameters
+        ----------
+        field : tuple
+            ("field_type", "fieldname") tuple
+
+        The remaining keyword arguments (width, resolution, center, height, periodic)
+        are all passed to YTSlice.to_frb().
+
+
+        """
+
+        # store our frb arguments for now. get_mesh_data will extract the frb.
+        self._frb_args = (width, resolution, center, height, periodic)
+        super().add_data(field)
+
+    def get_mesh_data(self, data_source, field):
+        # must return output from triangulate_mesh(vertices, data, indices)
+        frb = data_source.to_frb(*self._frb_args)
+        coords, conn, e_data = self._mesh_from_frb(frb, field)
+        return triangulate_mesh(coords, e_data, conn)
+
+    def _assemble(self, xe, ye, ze, nx, ny, nz, frb_array):
         # assemble elements! this is a first pass brute force approach...
 
         # containers that can be given to yt.load_unstructured()
@@ -78,17 +106,18 @@ class SliceData(MeshData):
         def sample_the_frb(ix, iy, iz):
             # the index order depends on which axis is orthogonal to our slice!
             if nx == 1:
-                data = frb_cell_center_vals[iy, iz]
+                data = frb_array[iy, iz]
             elif ny == 1:
-                data = frb_cell_center_vals[ix, iz]
+                data = frb_array[ix, iz]
             elif nz == 1:
-                data = frb_cell_center_vals[ix, iy]
+                data = frb_array[ix, iy]
             else:
                 raise ValueError("One of the mesh dimensions must have a single element!")
             return data
 
         # this could be vectorized. but it's not as bad as it could be since
-        # one of the dimensions will always have 1 element.
+        # one of the dimensions will always have 1 element. but it is still slow
+        # and needs to be improved...
         for ix in range(nx):
             for iy in range(ny):
                 for iz in range(nz):
@@ -121,29 +150,51 @@ class SliceData(MeshData):
         connectivity = np.array(connectivity)
         element_center_data = np.array(element_center_data)
 
-        print("unstructured mesh assembled!")
         return coords, connectivity, element_center_data
 
-    def unstructured_mesh_from_frb_slice(self, frb, field):
+    def _mesh_from_frb(self, frb, field):
+        """Construct an unstructured mesh of a slice's frb for the given field.
+
+        This function builds a hexahedral mesh with the frb values as
+        element-center values. Mesh vertices are given by a uniform grid surrounding
+        the center of each frb point that is a single element wide in the direction
+        normal to the plane. The thickness of the slice is set as a fraction of the
+        minimum cell width in the slice-axes.
+
+        Parameters
+        ----------
+        frb : FixedResolutionBuffer
+            generated from YTSlice.to_frb()
+        field : tuple
+            ("fieldtype", "fieldname")
+
+        Returns
+        -------
+        tuple
+            coords : ndarray, vertex coordinates with shape (Nverts, 3)
+            conn : ndarray, connectivity indices with shape (Ncells, 8)
+            e_center_data : ndarray, element-center data with shape (Ncells, )
+        """
 
         # extract frb values and extract slice info
         frb_vals = frb[field]
-        parent_slice = frb.data_source
-        coord = parent_slice.coord
-        bounds = frb.bounds
-        axis = parent_slice.axis
+        parent_slice = frb.data_source  # YTSlice object
+        coord = parent_slice.coord  # the position along the axis we're slicing at
+        bounds = frb.bounds  # (x min, x max, y min, y max) of the image axes
+        axis = parent_slice.axis  # the slice normal axis
 
-        # build a quasi-3d mesh. frb values will be cell-centered values, will build a grid to
-        # to surround the cell-centered values.
+        # build a 3d mesh. frb values will be cell-centered values, will build
+        # a grid to to surround the cell-centered values.
 
         # first decide on the thickness of our cells in the slice-orthoganal direction
         d1 = (bounds[1] - bounds[0]) / frb.buff_size[0]
         d2 = (bounds[2] - bounds[3]) / frb.buff_size[1]
-        pseudo_d = np.min([d1, d2]) / 1e2  # our cell width in the slice-orthoganal axis
+        slice_width_factor = 0.01  # could be an input
+        pseudo_d = np.min([d1, d2]) * slice_width_factor  # our slice width!
         pseudo_bounds = [coord - pseudo_d / 2., coord + pseudo_d / 2.]
 
-        # now set the bounds and number of cells in each direction. The axis orthogonal to slicing plane will
-        # always have 1 element.
+        # now set the bounds and number of cells in each direction. The axis
+        # orthogonal to slicing plane will always have 1 element.
         if axis == 0:
             nx = 1
             xlims = pseudo_bounds
@@ -164,51 +215,36 @@ class SliceData(MeshData):
             ny = frb.buff_size[1]
             ylims = [bounds[2], bounds[3]]
             nz = 1
-            ylims = pseudo_bounds
+            zlims = pseudo_bounds
 
-        # construct cell-center arrays, cell widths and cell vertices arrays for each axis
+        # construct cell-center arrays, cell widths and cell vertices arrays for
+        # each axis
         def get_grid_axis(lims, N):
             grid_spacing = (lims[1] - lims[0]) / N
             hlf = grid_spacing / 2.
             grid_edges = np.linspace(lims[0] - hlf, lims[1] + hlf, N+1)
-            # grid_centers = np.linspace(lims[0], lims[1], N)
             return grid_edges, grid_spacing
 
         xe, dx = get_grid_axis(xlims, nx)
         ye, dy = get_grid_axis(ylims, ny)
         ze, dz = get_grid_axis(zlims, nz)
 
-        # assemble the mesh -- slow right now....
-        coords, conn, e_center_data = self.assemble(xe, ye, ze, nx, ny, nz, frb_vals)
+        # get our unstructured mesh (slow right now)
+        coords, conn, e_center_data = self._assemble(xe, ye, ze, nx, ny, nz, frb_vals)
         return coords, conn, e_center_data
 
-    def add_data(self, field, width=1., resolution=(400, 400), center=None, height=None, periodic=False ):
-        # to_frb args and kwargs: width, resolution, center=None, height=None, periodic=False
-        # frb = self.data_source.to_frb(frb_width, frb_resolution, **frb_kwargs)
-        # store our frb arguments for now. get_mesh_data will extract the frb.
-        self._frb_args = (width, resolution, center, height, periodic)
 
-        super().add_data(field)
-
-    def get_mesh_data(self, data_source, field):
-        # must return output from triangulate_mesh(vertices, data, indices)
-        frb = data_source.to_frb(*self._frb_args)
-        coords, conn, e_data = self.unstructured_mesh_from_frb_slice(frb, field)
-
-        return triangulate_mesh(coords, e_data, conn)
-
-class SliceComposite(SceneData):
+class SliceComposite(MeshData):
     name = "slice_composite"
-    # data_source = traitlets.Instance(YTDataContainer)
-    texture_objects = traitlets.Dict(trait=traitlets.Instance(Texture3D))
-    texture_objects = traitlets.Dict(trait=traitlets.Instance(Texture3D))
-    blocks = traitlets.Dict(default_value=())
-    scale = traitlets.Bool(False)
-    size = traitlets.CInt(-1)
 
     def add_data(self, slices):
-        # must return output from triangulate_mesh(vertices, data, indices)
+        """combines SliceData objects into a single SliceComposite.
 
+        Parameters
+        ----------
+        slices : list or tuple
+            a list/tuple of SliceData objects that already have data added.
+        """
         if type(slices) not in (tuple, list):
             slices = [slices]
 
@@ -228,7 +264,6 @@ class SliceComposite(SceneData):
             indices.append( slc.vertex_array.indices + index_max)
             index_max += slc.size
 
-
         verts = np.concatenate(verts)
         edata = np.concatenate(edata)
         indices = np.concatenate(indices)
@@ -241,7 +276,3 @@ class SliceComposite(SceneData):
         )
         self.vertex_array.indices = indices
         self.size = indices.size
-
-    @traitlets.default("vertex_array")
-    def _default_vertex_array(self):
-        return VertexArray(name="slice_composite_info", each=0)

--- a/yt_idv/scene_data/mesh.py
+++ b/yt_idv/scene_data/mesh.py
@@ -2,7 +2,7 @@ import numpy as np
 import traitlets
 from yt.data_objects.data_containers import YTDataContainer
 from yt.utilities.lib.mesh_triangulation import triangulate_mesh
-
+from yt import load_unstructured_mesh
 from yt_idv.opengl_support import Texture3D, VertexArray, VertexAttribute
 from yt_idv.scene_data.base_data import SceneData
 
@@ -59,3 +59,189 @@ class MeshData(SceneData):
     @traitlets.default("vertex_array")
     def _default_vertex_array(self):
         return VertexArray(name="mesh_info", each=0)
+
+
+class SliceData(MeshData):
+    name = "slice"
+    _frb_args = None
+    _mesh_ds = None
+
+    def assemble(self, xe, ye, ze, nx, ny, nz, frb_cell_center_vals):
+        # assemble elements! this is a first pass brute force approach...
+
+        # containers that can be given to yt.load_unstructured()
+        coords = []
+        connectivity = []
+        element_center_data = []
+        icoord = 0
+
+        def sample_the_frb(ix, iy, iz):
+            # the index order depends on which axis is orthogonal to our slice!
+            if nx == 1:
+                data = frb_cell_center_vals[iy, iz]
+            elif ny == 1:
+                data = frb_cell_center_vals[ix, iz]
+            elif nz == 1:
+                data = frb_cell_center_vals[ix, iy]
+            else:
+                raise ValueError("One of the mesh dimensions must have a single element!")
+            return data
+
+        # this could be vectorized. but it's not as bad as it could be since
+        # one of the dimensions will always have 1 element.
+        for ix in range(nx):
+            for iy in range(ny):
+                for iz in range(nz):
+
+                    # add vertices of our hexahedral elements (in the proper order!)
+                    # to our coordinate array (this will repeat vertices in the
+                    # coordinate array)
+                    verts = [
+                        [xe[ix], ye[iy], ze[iz]],
+                        [xe[ix + 1], ye[iy], ze[iz]],
+                        [xe[ix + 1], ye[iy + 1], ze[iz]],
+                        [xe[ix], ye[iy + 1], ze[iz]],
+                        [xe[ix], ye[iy], ze[iz + 1]],
+                        [xe[ix + 1], ye[iy], ze[iz + 1]],
+                        [xe[ix + 1], ye[iy + 1], ze[iz + 1]],
+                        [xe[ix], ye[iy + 1], ze[iz + 1]]
+                    ]
+                    coords += verts
+
+                    # because we are repeating our vertices, connectivity can
+                    # just be incremented
+                    connectivity += [[i for i in range(icoord, icoord + 8)], ]
+                    icoord += 8
+
+                    these_vals = sample_the_frb(ix, iy, iz)
+                    element_center_data.append(these_vals)
+
+        # finalize our arrays
+        coords = np.array(coords)
+        connectivity = np.array(connectivity)
+        element_center_data = np.array(element_center_data)
+
+        print("unstructured mesh assembled!")
+        return coords, connectivity, element_center_data
+
+    def unstructured_mesh_from_frb_slice(self, frb, field):
+
+        # extract frb values and extract slice info
+        frb_vals = frb[field]
+        parent_slice = frb.data_source
+        coord = parent_slice.coord
+        bounds = frb.bounds
+        axis = parent_slice.axis
+
+        # build a quasi-3d mesh. frb values will be cell-centered values, will build a grid to
+        # to surround the cell-centered values.
+
+        # first decide on the thickness of our cells in the slice-orthoganal direction
+        d1 = (bounds[1] - bounds[0]) / frb.buff_size[0]
+        d2 = (bounds[2] - bounds[3]) / frb.buff_size[1]
+        pseudo_d = np.min([d1, d2]) / 1e2  # our cell width in the slice-orthoganal axis
+        pseudo_bounds = [coord - pseudo_d / 2., coord + pseudo_d / 2.]
+
+        # now set the bounds and number of cells in each direction. The axis orthogonal to slicing plane will
+        # always have 1 element.
+        if axis == 0:
+            nx = 1
+            xlims = pseudo_bounds
+            ny = frb.buff_size[0]
+            ylims = [bounds[0], bounds[1]]
+            nz = frb.buff_size[1]
+            zlims = [bounds[2], bounds[3]]
+        elif axis == 1:
+            nx = frb.buff_size[0]
+            xlims = [bounds[0], bounds[1]]
+            ny = 1
+            ylims = pseudo_bounds
+            nz = frb.buff_size[1]
+            zlims = [bounds[2], bounds[3]]
+        elif axis == 2:
+            nx = frb.buff_size[0]
+            xlims = [bounds[0], bounds[1]]
+            ny = frb.buff_size[1]
+            ylims = [bounds[2], bounds[3]]
+            nz = 1
+            ylims = pseudo_bounds
+
+        # construct cell-center arrays, cell widths and cell vertices arrays for each axis
+        def get_grid_axis(lims, N):
+            grid_spacing = (lims[1] - lims[0]) / N
+            hlf = grid_spacing / 2.
+            grid_edges = np.linspace(lims[0] - hlf, lims[1] + hlf, N+1)
+            # grid_centers = np.linspace(lims[0], lims[1], N)
+            return grid_edges, grid_spacing
+
+        xe, dx = get_grid_axis(xlims, nx)
+        ye, dy = get_grid_axis(ylims, ny)
+        ze, dz = get_grid_axis(zlims, nz)
+
+        # assemble the mesh -- slow right now....
+        coords, conn, e_center_data = self.assemble(xe, ye, ze, nx, ny, nz, frb_vals)
+        return coords, conn, e_center_data
+
+    def add_data(self, field, width=1., resolution=(400, 400), center=None, height=None, periodic=False ):
+        # to_frb args and kwargs: width, resolution, center=None, height=None, periodic=False
+        # frb = self.data_source.to_frb(frb_width, frb_resolution, **frb_kwargs)
+        # store our frb arguments for now. get_mesh_data will extract the frb.
+        self._frb_args = (width, resolution, center, height, periodic)
+
+        super().add_data(field)
+
+    def get_mesh_data(self, data_source, field):
+        # must return output from triangulate_mesh(vertices, data, indices)
+        frb = data_source.to_frb(*self._frb_args)
+        coords, conn, e_data = self.unstructured_mesh_from_frb_slice(frb, field)
+
+        return triangulate_mesh(coords, e_data, conn)
+
+class SliceComposite(SceneData):
+    name = "slice_composite"
+    # data_source = traitlets.Instance(YTDataContainer)
+    texture_objects = traitlets.Dict(trait=traitlets.Instance(Texture3D))
+    texture_objects = traitlets.Dict(trait=traitlets.Instance(Texture3D))
+    blocks = traitlets.Dict(default_value=())
+    scale = traitlets.Bool(False)
+    size = traitlets.CInt(-1)
+
+    def add_data(self, slices):
+        # must return output from triangulate_mesh(vertices, data, indices)
+
+        if type(slices) not in (tuple, list):
+            slices = [slices]
+
+        verts = []
+        edata = []
+        indices = []
+        index_max = 0
+        for slc in slices:
+            if isinstance(slc, SliceData) is False:
+                raise TypeError("all slices must be a SliceData objects")
+
+            for attr in slc.vertex_array.attributes:
+                if attr.name == "model_vertex":
+                    verts.append(attr.data)
+                elif attr.name == "vertex_data":
+                    edata.append(attr.data)
+            indices.append( slc.vertex_array.indices + index_max)
+            index_max += slc.size
+
+
+        verts = np.concatenate(verts)
+        edata = np.concatenate(edata)
+        indices = np.concatenate(indices)
+
+        self.vertex_array.attributes.append(
+            VertexAttribute(name="model_vertex", data=verts)
+        )
+        self.vertex_array.attributes.append(
+            VertexAttribute(name="vertex_data", data=edata.astype("f4"))
+        )
+        self.vertex_array.indices = indices
+        self.size = indices.size
+
+    @traitlets.default("vertex_array")
+    def _default_vertex_array(self):
+        return VertexArray(name="slice_composite_info", each=0)


### PR DESCRIPTION
This adds a couple of mesh rendering data classes to allow 2d slices to be plotted in 3d. The basic approach is to generate a fixed resolution buffer from a `YTSlice` and build a uniform hexahedral mesh with the frb values as element-center values (which is then triangulated following `MeshData`). The slice thickness is small (but finite), calculated as a fraction of the cell spacing in the other axes. The new `SliceData` class handles all this for a single slice (see `examples/amr_slices.py`) while `SliceDataComposite` can concatenate multiple `SliceData` objects without re-generating the meshes so that the rendering will use a single colormap across the slices (see `examples/amr_slices_composites.py`).

Currently a draft PR because assembling the unstructured mesh is slow -- started with a brute force nested loop that needs to be improved (should be vectorizable, or maybe yt has some utility to help here...). The examples here take ~15 seconds per slice to generate the `SliceData` objects. Once generated and added to the rendering context, it's fast! (also haven't run any style checks yet...)

Here's a couple screen shots from the single slice example:

![snap_0000](https://user-images.githubusercontent.com/22038879/113781696-b0f68800-96f6-11eb-9ba7-3d873ad5e1af.png)
![snap_0001](https://user-images.githubusercontent.com/22038879/113781701-b227b500-96f6-11eb-8887-fb4230400221.png)
