### PR TITLE
fix block data extrema calculation with nan values

### DIFF
--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -56,8 +56,8 @@ class BlockCollection(SceneData):
                 block.RightEdge -= left_min
                 block.RightEdge /= scale
         for i, block in enumerate(self.data_source.tiles.traverse()):
-            self.min_val = min(self.min_val, np.nanmin(np.abs(block.my_data[0]).min()))
-            self.max_val = max(self.max_val, np.nanmax(np.abs(block.my_data[0]).max()))
+            self.min_val = min(self.min_val, np.nanmin(np.abs(block.my_data[0])).min())
+            self.max_val = max(self.max_val, np.nanmax(np.abs(block.my_data[0])).max())
             self.blocks[id(block)] = (i, block)
             vert.append([1.0, 1.0, 1.0, 1.0])
             dds = (block.RightEdge - block.LeftEdge) / block.source_mask.shape


### PR DESCRIPTION
Was trying to load a dataset with lots of nans and  was getting the following error:

```
/home/chris/src/yt_/yt_idv/yt_idv/scene_data/block_collection.py:59: RuntimeWarning: All-NaN axis encountered
  self.min_val = min(self.min_val, np.nanmin(np.abs(block.my_data[0]).min()))
/home/chris/src/yt_/yt_idv/yt_idv/scene_data/block_collection.py:60: RuntimeWarning: All-NaN axis encountered
  self.max_val = max(self.max_val, np.nanmax(np.abs(block.my_data[0]).max()))
/home/chris/src/yt_/yt_idv/yt_idv/scene_data/block_collection.py:123: RuntimeWarning: invalid value encountered in true_divide
  n_data = (n_data - self.min_val) / (
```

Switching the order of the `nanmin` (`nanmax`) and `min` (`max`) operations fixed it. 