### PR TITLE
explicitly set the depth_size for pyglet config

### DIFF
--- a/yt_idv/rendering_contexts/pyglet_context.py
+++ b/yt_idv/rendering_contexts/pyglet_context.py
@@ -41,7 +41,11 @@ class PygletRenderingContext(pyglet.window.Window, BaseContext):
     ):
         self.offscreen = not visible
         config = pyglet.gl.Config(
-            major_version=3, minor_version=3, forward_compat=True, double_buffer=True
+            major_version=3,
+            minor_version=3,
+            forward_compat=True,
+            double_buffer=True,
+            depth_size=24,
         )
         super(PygletRenderingContext, self).__init__(
             width, height, config=config, visible=visible, caption=title


### PR DESCRIPTION
This PR explicitly sets `depth_size = 24` in the pyglet config to avoid the interesting case where `depth_size` defaults to 0 on some systems... 