### PR TITLE
adjusting bump2version config and bumping

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 0.2.1
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
+
+[bumpversion:file:yt_idv/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,11 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
+[bumpversion:file:setup.cfg]
+search = version = {current_version}
+replace = version = {new_version}
 
 [bumpversion:file:yt_idv/__init__.py]
 search = __version__ = "{current_version}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,19 +65,6 @@ dev =
     watchdog==0.9.0
     wheel==0.33.6
 
-[bumpversion]
-current_version = 0.2.1
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
-[bumpversion:file:yt_idv/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idv
-version = 0.2.1
+version = 0.2.2
 description = Interactive Volume Rendering for yt
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/yt_idv/__init__.py
+++ b/yt_idv/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Matthew Turk"""
 __email__ = "matthewturk@gmail.com"
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 import os
 


### PR DESCRIPTION
This adjusts the bum2version configuration and bumps the patch number. 

The bump2version configuration is now in its own file to handle the case where version is set in `setup.cfg` metadata. There's a number of issues and PRs related to having the config and canonical version in `setup.cfg` (e.g., [this one](https://github.com/c4urself/bump2version/issues/62)], easiest fix for now is to just have a separate `.bumpversion.cfg` file. 

I'm not 100% sure this will cut a full release -- I may need to separately push the git tags?