### PR TITLE
manifest fix and another patch release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.2.3
 commit = True
 tag = True
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,7 @@ recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
+global-include *.pyx
+global-include *.pxd
+
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt_idv
-version = 0.2.2
+version = 0.2.3
 description = Interactive Volume Rendering for yt
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/yt_idv/__init__.py
+++ b/yt_idv/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Matthew Turk"""
 __email__ = "matthewturk@gmail.com"
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 import os
 


### PR DESCRIPTION
This should take care of the remaining setup issue (the `pyx` files were not included in the sdist tarball). This bumps the version patch number again, I'll trigger another release after this gets merged.