### PR TITLE
add a display_name attribute

### DIFF
--- a/examples/amr_volume_rendering_with_curves.py
+++ b/examples/amr_volume_rendering_with_curves.py
@@ -41,6 +41,7 @@ sg = rc.add_scene(ds, "density", no_ghost=True)
 curved = CurveData()
 curved.add_data(streamlines.streamlines[0])
 curve_render = CurveRendering(data=curved, curve_rgba=(1.0, 0.0, 0.0, 1.0))
+curve_render.display_name = "single streamline"
 rc.scene.data_objects.append(curved)
 rc.scene.components.append(curve_render)
 
@@ -52,6 +53,7 @@ for stream in streamlines.streamlines[1:]:
 curve_collection.add_data()  # call add_data() after done adding curves
 
 cc_render = CurveCollectionRendering(data=curve_collection)
+cc_render.display_name = "multiple streamlines"
 rc.scene.data_objects.append(curve_collection)
 rc.scene.components.append(cc_render)
 

--- a/examples/octree_volume_rendering.py
+++ b/examples/octree_volume_rendering.py
@@ -12,7 +12,7 @@ sg = rc.add_scene(ds, None, no_ghost=True)
 
 odata = OctreeBlockCollection(data_source=dd)
 odata.add_data("density")
-oren = OctreeBlockRendering(data=odata)
+oren = OctreeBlockRendering(data=odata, display_name="density")
 
 sg.data_objects.append(odata)
 sg.components.append(oren)

--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -54,6 +54,8 @@ class SceneComponent(traitlets.HasTraits):
     _program2_invalid = True
     _cmap_bounds_invalid = True
 
+    display_name = traitlets.Unicode(allow_none=True)
+
     # These attributes are
     cmap_min = traitlets.CFloat(None, allow_none=True)
     cmap_max = traitlets.CFloat(None, allow_none=True)
@@ -118,6 +120,10 @@ class SceneComponent(traitlets.HasTraits):
         changed = changed or _
 
         return changed
+
+    @traitlets.default("display_name")
+    def _default_display_name(self):
+        return self.name
 
     @traitlets.default("render_method")
     def _default_render_method(self):

--- a/yt_idv/simple_gui.py
+++ b/yt_idv/simple_gui.py
@@ -61,7 +61,7 @@ class SimpleGUI:
             changed = changed or _
             # imgui.show_style_editor()
             for i, element in enumerate(scene):
-                if imgui.tree_node(f"element {i + 1}: {element.name}"):
+                if imgui.tree_node(f"element {i + 1}: {element.display_name}"):
                     changed = changed or element.render_gui(imgui, self.renderer, scene)
                     imgui.tree_pop()
             self.window._do_update = self.window._do_update or changed


### PR DESCRIPTION
Adds a `display_name` attribute to the base `SceneComponent` (with a default to the `.name` attribute) so you can set a custom name for display in the GUI. modified the streamline example: 

![Screenshot from 2022-10-26 15-31-37](https://user-images.githubusercontent.com/22038879/198131756-9ba4876c-0d6e-416b-808a-0547cf99e657.png)
