### PR TITLE
flake8, setup-cfg-fmt collision fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,15 +73,16 @@ universal = 1
 max-line-length = 88
 exclude = docs,
     */__init__.py
-ignore = E203, # Whitespace before ':' (black compatibility)
-    E231, # Missing whitespace after ',', ';', or ':'
-    E266, # Too many leading '#' for block comment
-    E302, # Expected 2 blank lines, found 0
-    E306, # Expected 1 blank line before a nested definition
-    E741, # Do not use variables named 'I', 'O', or 'l'
-    W503, # Line break occurred before a binary operator (black compatibility)
-    W605, # Invalid escape sequence 'x'
-    B302, # this is a python 3 compatibility warning, not relevant since don't support python 2 anymore
+ignore =
+    E203,
+    E231,
+    E266,
+    E302,
+    E306,
+    E741,
+    W503,
+    W605,
+    B302,
 
 [aliases]
 test = pytest


### PR DESCRIPTION
together with #63 this should get precommit.ci passing again. 

newer flake8 versions require that

```
E231, # Missing whitespace after ',', ';', or ':'
```
be changed to 
```
# Missing whitespace after ',', ';', or ':'
E231, 
```

and then `setup-cfg-fmt` ends up removing those comment lines when pre-commit runs.... maybe not ideal but I don't see a way around it short of remove `setup-cfg-fmt` checks entirely. 

