### PR TITLE
First attempt at preprocessor directives

### DIFF
--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -264,7 +264,7 @@ class Shader(traitlets.HasTraits):
         GLValue(),
         default_value=("none", "none", "none", "none"),
     )
-    preprocessor_defs = traitlets.List(trait = traitlets.Unicode)
+    preprocessor_defs = traitlets.List(trait=traitlets.Unicode)
 
     def _get_source(self, source):
         if ";" in source:
@@ -299,8 +299,7 @@ class Shader(traitlets.HasTraits):
 
     @property
     def defines(self):
-        return "\n".join([f"#define {var}" for var in
-                         self.preprocessor_defs])
+        return "\n".join([f"#define {var}" for var in self.preprocessor_defs])
 
     def compile(self, source=None):
         if source is None:

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -306,8 +306,6 @@ class Shader(traitlets.HasTraits):
             source = self.source
             if source is None:
                 raise RuntimeError
-        if parameters is not None:
-            raise NotImplementedError
         source = self._get_source(source)
         shader_type_enum = getattr(GL, f"GL_{self.shader_type.upper()}_SHADER")
         shader = GL.glCreateShader(shader_type_enum)

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -277,9 +277,12 @@ class Shader(traitlets.HasTraits):
         # files.
         if not isinstance(source, (tuple, list)):
             source = (source,)
-        source = ("header.inc.glsl",) + tuple(self.preprocessor_defs) + (
-            "known_uniforms.inc.glsl",
-        ) + tuple(source)
+        source = (
+            ("header.inc.glsl",)
+            + tuple(self.preprocessor_defs)
+            + ("known_uniforms.inc.glsl",)
+            + tuple(source)
+        )
         full_source = []
         for fn in source:
             if isinstance(fn, tuple):

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -264,6 +264,7 @@ class Shader(traitlets.HasTraits):
         GLValue(),
         default_value=("none", "none", "none", "none"),
     )
+    preprocessor_defs = traitlets.List(trait = traitlets.Unicode)
 
     def _get_source(self, source):
         if ";" in source:
@@ -296,7 +297,12 @@ class Shader(traitlets.HasTraits):
         source = _NULL_SOURCES[self.shader_type]
         self.compile(source=source)
 
-    def compile(self, source=None, parameters=None):
+    @property
+    def defines(self):
+        return "\n".join([f"#define {var}" for var in
+                         self.preprocessor_defs])
+
+    def compile(self, source=None):
         if source is None:
             source = self.source
             if source is None:
@@ -308,7 +314,7 @@ class Shader(traitlets.HasTraits):
         shader = GL.glCreateShader(shader_type_enum)
         # We could do templating here if we wanted.
         self.shader_source = source
-        GL.glShaderSource(shader, source)
+        GL.glShaderSource(shader, [self.defines, source])
         GL.glCompileShader(shader)
         result = GL.glGetShaderiv(shader, GL.GL_COMPILE_STATUS)
         if not (result):


### PR DESCRIPTION
This should be enough to get the shader programs to accept preprocessor directives.
It's not quite ready to go yet, because right now the shader objects themselves are created inside the shader program, and I'm not passing the full set of preprocessor directives down.

How it works right now is that `base_component.py` has the function `_recompile_shader`.  This deletes the shaders and sets `_program1_invalid` and `_program2_invalid` to True.
The next time the call gets made to `program1`, it is a property that calls:

```
self._program1 = ShaderProgram(
    self.vertex_shader, self.fragment_shader, self.geometry_shader
)
```

We'll need to include in this a set of parameters that are defined on the base component.
I think this could be a property defined by each subclass that translates properties/traits into strings.
