### PR TITLE
Set unitary scale for the block collection

### DIFF
--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -79,10 +79,11 @@ class BlockCollection(SceneData):
         self.diagonal = np.sqrt(((RE - LE) ** 2).sum())
         # Now we set up our buffer
         vert = np.array(vert, dtype="f4")
-        dx = np.array(dx, dtype="f4")
-        le = np.array(le, dtype="f4")
-        re = np.array(re, dtype="f4")
-
+        units = self.data_source.ds.units
+        ratio = (units.code_length / units.unitary).base_value
+        dx = np.array(dx, dtype="f4") * ratio
+        le = np.array(le, dtype="f4") * ratio
+        re = np.array(re, dtype="f4") * ratio
         self.vertex_array.attributes.append(
             VertexAttribute(name="model_vertex", data=vert)
         )


### PR DESCRIPTION
We utilize unitary scaling almost everywhere when setting positions;
this is even built into the `YTPositionTrait` object.  However, we don't
utilize this in the setting of the left and right edges of the objects,
because our `PartitionedGrid` objects don't have units associated with
their attributes.

One side effect of this is that when loading a dataset where the unitary
scale is wildly different from the `code_length` scale, our camera
position is strange and set in the wrong absolute coordinate values.
