### PR TITLE
preprocessor directives followup 

### DIFF
--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -226,7 +226,7 @@ class SceneComponent(traitlets.HasTraits):
         else:
             self._program2_pp_defs.clear_definition("fragment", ("USE_DB", ""))
 
-        # update the colormap_fragmet with current render method
+        # update the colormap fragment with current render method
         current_combo = component_shaders[self.name][self.render_method]
         pp_defs = self._program2_pp_defs.get_shader_defs("fragment")
         self.colormap_fragment = current_combo["second_fragment"], pp_defs

--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -147,6 +147,14 @@ class SceneComponent(traitlets.HasTraits):
     def _default_render_method(self):
         return default_shader_combos[self.name]
 
+    @traitlets.default("_program1_pp_defs")
+    def _default_program1_pp_defs(self):
+        return PreprocessorDefinitionState()
+
+    @traitlets.default("_program2_pp_defs")
+    def _default_program2_pp_defs(self):
+        return PreprocessorDefinitionState()
+
     @traitlets.observe("render_method")
     def _change_render_method(self, change):
         new_combo = component_shaders[self.name][change["new"]]

--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -159,21 +159,26 @@ class SceneComponent(traitlets.HasTraits):
     def _change_render_method(self, change):
         new_combo = component_shaders[self.name][change["new"]]
         with self.hold_trait_notifications():
-            self.vertex_shader = new_combo[
-                "first_vertex"
-            ], self._program1_pp_defs.get_shader_defs("vertex")
-            self.fragment_shader = new_combo[
-                "first_fragment"
-            ], self._program1_pp_defs.get_shader_defs("fragment")
-            self.geometry_shader = new_combo.get(
-                "first_geometry", None
-            ), self._program1_pp_defs.get_shader_defs("geometry")
-            self.colormap_vertex = new_combo[
-                "second_vertex"
-            ], self._program2_pp_defs.get_shader_defs("vertex")
-            self.colormap_fragment = new_combo[
-                "second_fragment"
-            ], self._program2_pp_defs.get_shader_defs("fragment")
+            self.vertex_shader = (
+                new_combo["first_vertex"],
+                self._program1_pp_defs["vertex"],
+            )
+            self.fragment_shader = (
+                new_combo["first_fragment"],
+                self._program1_pp_defs["fragment"],
+            )
+            self.geometry_shader = (
+                new_combo.get("first_geometry", None),
+                self._program1_pp_defs["geometry"],
+            )
+            self.colormap_vertex = (
+                new_combo["second_vertex"],
+                self._program2_pp_defs["vertex"],
+            )
+            self.colormap_fragment = (
+                new_combo["second_fragment"],
+                self._program2_pp_defs["fragment"],
+            )
 
     @traitlets.observe("render_method")
     def _add_initial_isolayer(self, change):
@@ -218,9 +223,6 @@ class SceneComponent(traitlets.HasTraits):
 
         # update the preprocessor state: USE_DB only present in the second
         # program, only update that one.
-        if self._program2_pp_defs is None:
-            self._program2_pp_defs = PreprocessorDefinitionState()
-
         if changed["new"]:
             self._program2_pp_defs.add_definition("fragment", ("USE_DB", ""))
         else:
@@ -228,7 +230,7 @@ class SceneComponent(traitlets.HasTraits):
 
         # update the colormap fragment with current render method
         current_combo = component_shaders[self.name][self.render_method]
-        pp_defs = self._program2_pp_defs.get_shader_defs("fragment")
+        pp_defs = self._program2_pp_defs["fragment"]
         self.colormap_fragment = current_combo["second_fragment"], pp_defs
         self._recompile_shader()
 

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -407,14 +407,14 @@ class Shader(traitlets.HasTraits):
         self.delete_shader()
 
 
-def _instantiate_shader_from_str(shader_type, value, preprocessor_defs=None):
+def _validate_shader(shader_type, value, allow_null=True, preprocessor_defs=None):
     shader_info = known_shaders[shader_type][value]
     shader_info.setdefault("shader_type", shader_type)
     shader_info["use_separate_blend"] = bool("blend_func_separate" in shader_info)
     shader_info.setdefault("shader_name", value)
     if preprocessor_defs is not None:
         shader_info["preprocessor_defs"] = preprocessor_defs
-    return Shader(**shader_info)
+    return Shader(allow_null=allow_null, **shader_info)
 
 
 class ShaderTrait(traitlets.TraitType):
@@ -430,7 +430,7 @@ class ShaderTrait(traitlets.TraitType):
                     value = value[0]
                 else:
                     preprocessor_defs = None
-                return _instantiate_shader_from_str(
+                return _validate_shader(
                     shader_type, value, preprocessor_defs=preprocessor_defs
                 )
             except KeyError:

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -82,7 +82,8 @@ class ShaderProgram:
         The geometry shader used in the pipeline; optional.
 
     preprocessor_defs : PreprocessorDefinitionState
-        a dictionary of preprocessor tuples for each shader; optional.
+        a PreprocessorDefinitionState instance defining any preprocessor
+        definitions if used; optional.
 
     """
 

--- a/yt_idv/shaders/apply_colormap.frag.glsl
+++ b/yt_idv/shaders/apply_colormap.frag.glsl
@@ -5,9 +5,9 @@ out vec4 color;
 void main(){
    float scaled = 0;
    #ifdef USE_DB
-      scaled = texture(db_tex, UV).x;
+   scaled = texture(db_tex, UV).x;
    #else
-      scaled = texture(fb_tex, UV).x;
+   scaled = texture(fb_tex, UV).x;
    #endif
    float alpha = texture(fb_tex, UV).a;  // the incoming framebuffer alpha
    if (alpha == 0.0) discard;

--- a/yt_idv/shaders/apply_colormap.frag.glsl
+++ b/yt_idv/shaders/apply_colormap.frag.glsl
@@ -4,11 +4,11 @@ out vec4 color;
 
 void main(){
    float scaled = 0;
-   if (use_db) {
+   #ifdef USE_DB
       scaled = texture(db_tex, UV).x;
-   } else {
+   #else
       scaled = texture(fb_tex, UV).x;
-   }
+   #endif
    float alpha = texture(fb_tex, UV).a;  // the incoming framebuffer alpha
    if (alpha == 0.0) discard;
    float cm = cmap_min;

--- a/yt_idv/shaders/known_uniforms.inc.glsl
+++ b/yt_idv/shaders/known_uniforms.inc.glsl
@@ -51,9 +51,6 @@ uniform sampler3D ds_tex[6];
 // ray tracing control
 uniform float sample_factor;
 
-// depth buffer control
-uniform bool use_db;
-
 // curve drawing control
 uniform vec4 curve_rgba;
 

--- a/yt_idv/tests/test_preprocessor_state.py
+++ b/yt_idv/tests/test_preprocessor_state.py
@@ -1,0 +1,29 @@
+import pytest
+
+from yt_idv.shader_objects import PreprocessorDefinitionState
+
+
+def test_preprocessor_definition_state():
+
+    pds = PreprocessorDefinitionState()
+
+    pds.add_definition("fragment", ("USE_DB", ""))
+    assert ("USE_DB", "") in pds["fragment"]
+    pds.add_definition("vertex", ("placeholder", ""))
+    assert ("placeholder", "") in pds["vertex"]
+
+    with pytest.raises(ValueError, match="shader_type must be"):
+        pds.add_definition("not_a_shader_type", ("any_str", ""))
+
+    pds.clear_definition("fragment", ("USE_DB", ""))
+    assert ("USE_DB", "") not in pds["fragment"]
+
+    pds.reset("vertex")
+    assert len(pds.vertex) == 0
+
+    pds.add_definition("fragment", ("USE_DB", ""))
+    pds.add_definition("geometry", ("placeholder", ""))
+    pds.add_definition("vertex", ("placeholder", ""))
+    pds.reset()
+    for shadertype in pds._valid_shader_types:
+        assert len(pds._get_dict(shadertype)) == 0

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -62,6 +62,11 @@ def test_snapshots(osmesa_fake_amr, image_store):
     image_store(osmesa_fake_amr)
 
 
+def test_depth_buffer_toggle(osmesa_fake_amr, image_store):
+    osmesa_fake_amr.scene.components[0].use_db = True
+    image_store(osmesa_fake_amr)
+
+
 def test_slice(osmesa_fake_amr, image_store):
     osmesa_fake_amr.scene.components[0].render_method = "slice"
     osmesa_fake_amr.scene.components[0].slice_position = (0.5, 0.5, 0.5)


### PR DESCRIPTION
This PR follows on #70 and

* adds the ability to toggle preprocessor directives interactively (by triggering re-compilation)
* replaces the depth buffer toggle (`use_db`) with a preprocessor `USE_DB` definition. I'm actually not sure switching this to a pre-processor directive is better or worse, but it does nicely illustrate the functionality. 



