### PR TITLE
add 3.10,3.11 to CI, drop 3.8 test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9, '3.10', '3.11']
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
I know we removed 3.10 at some point from CI. But it passes locally without a problem, so figured I'd try adding it back to see what happens. also added 3.11 out of curiosity...

This also drops the 3.8 test... maybe it shouldn't? 