### PR TITLE
update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,11 @@ sphinx:
 formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 python:
-  version: 3.7
   install:
-    - requirements: docs/requirements.txt
+  - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,12 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+# Specify the build os and python version
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 # Build documentation with MkDocs
 #mkdocs:
 #  configuration: mkdocs.yml
@@ -16,12 +22,8 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF
 formats: []
 
-# Optionally set the version of Python and requirements required to build your docs
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.9"
 
+# Optionally set the Python requirements required to build your docs
 python:
   install:
   - requirements: docs/requirements.txt


### PR DESCRIPTION
Looks like it's been a while since the rtd config has been updated, and builds are currently failing due to not having `build.os` specified (https://readthedocs.org/projects/yt-idv/builds/22333916/). I think this should do the trick. 