### PR TITLE
add test for curves, fix traitlets deprecation warnings, update github action versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,5 +31,5 @@ jobs:
     - uses: actions/upload-artifact@v4
       name: Upload pytest report
       with:
-        name: pytest-report
+        name: pytest-report-py-${{ matrix.python-version }}
         path: report.html

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install osmesa
       run: |
         sudo apt-get update && sudo apt-get upgrade
@@ -28,7 +28,7 @@ jobs:
       env:
           PYOPENGL_PLATFORM: osmesa
       run: pytest --html=report.html --self-contained-html
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload pytest report
       with:
         name: pytest-report

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install check-build dependencies

--- a/.github/workflows/check-min-numpy.yaml
+++ b/.github/workflows/check-min-numpy.yaml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run min numpy tests
 
 on: [pull_request]
 

--- a/.github/workflows/check-min-numpy.yaml
+++ b/.github/workflows/check-min-numpy.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install osmesa
       run: |
         sudo apt-get update && sudo apt-get upgrade
@@ -28,7 +28,7 @@ jobs:
       env:
           PYOPENGL_PLATFORM: osmesa
       run: pytest --html=report.html --self-contained-html
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload pytest report
       with:
         name: pytest-report

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install pypa/build

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ ENV/
 
 # Screenshots
 snap_*.png
+
+# pytest outputs
+report.html

--- a/yt_idv/scene_annotations/grid_outlines.py
+++ b/yt_idv/scene_annotations/grid_outlines.py
@@ -14,7 +14,7 @@ class GridOutlines(SceneAnnotation):
     name = "grid_outline"
     data = traitlets.Instance(GridPositions)
     box_width = traitlets.CFloat(0.25)  # quarter of a dx
-    box_color = traitlets.Tuple((1.0, 1.0, 1.0), trait=traitlets.CFloat())
+    box_color = traitlets.Tuple((1.0, 1.0, 1.0)).tag(trait=traitlets.CFloat())
     box_alpha = traitlets.CFloat(1.0)
 
     def draw(self, scene, program):

--- a/yt_idv/scene_components/blocks.py
+++ b/yt_idv/scene_components/blocks.py
@@ -27,8 +27,8 @@ class BlockRendering(SceneComponent):
     tf_min = traitlets.CFloat(0.0)
     tf_max = traitlets.CFloat(1.0)
     tf_log = traitlets.Bool(True)
-    slice_position = traitlets.Tuple((0.5, 0.5, 0.5), trait=traitlets.CFloat())
-    slice_normal = traitlets.Tuple((1.0, 0.0, 0.0), trait=traitlets.CFloat())
+    slice_position = traitlets.Tuple((0.5, 0.5, 0.5)).tag(trait=traitlets.CFloat())
+    slice_normal = traitlets.Tuple((1.0, 0.0, 0.0)).tag(trait=traitlets.CFloat())
 
     priority = 10
 

--- a/yt_idv/scene_components/curves.py
+++ b/yt_idv/scene_components/curves.py
@@ -14,7 +14,7 @@ class CurveRendering(SceneComponent):
     name = "curve_rendering"
     data = traitlets.Instance(CurveData, help="The curve data.")
     line_width = traitlets.CFloat(1.0)
-    curve_rgba = traitlets.Tuple((1.0, 1.0, 1.0, 1.0), trait=traitlets.CFloat())
+    curve_rgba = traitlets.Tuple((1.0, 1.0, 1.0, 1.0)).tag(trait=traitlets.CFloat())
     priority = 10
 
     def render_gui(self, imgui, renderer, scene):

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -2,12 +2,15 @@
 
 import base64
 
+import numpy as np
 import pytest
 import yt
 import yt.testing
 from pytest_html import extras
 
 import yt_idv
+from yt_idv.scene_components.curves import CurveCollectionRendering, CurveRendering
+from yt_idv.scene_data.curve import CurveCollection, CurveData
 
 
 @pytest.fixture(autouse=True)
@@ -116,3 +119,30 @@ def test_annotate_text(osmesa_empty, image_store):
 def test_isocontour_functionality(osmesa_fake_amr, image_store):
     osmesa_fake_amr.scene.components[0].render_method = "isocontours"
     image_store(osmesa_fake_amr)
+
+
+def test_curves(osmesa_fake_amr, image_store):
+    # add a single curve
+
+    curved = CurveData()
+    x1d = np.linspace(0, 1, 10)
+    xyz = np.column_stack([x1d, x1d, x1d])
+    curved.add_data(xyz)
+    curve_render = CurveRendering(data=curved, curve_rgba=(1.0, 0.0, 0.0, 1.0))
+    curve_render.display_name = "single streamline"
+    osmesa_fake_amr.scene.data_objects.append(curved)
+    osmesa_fake_amr.scene.components.append(curve_render)
+
+    curve_collection = CurveCollection()
+    curve_collection.add_curve(xyz * 2.0)
+    curve_collection.add_curve(xyz * 3.0)
+    curve_collection.add_data()  # call add_data() after done adding curves
+
+    cc_render = CurveCollectionRendering(data=curve_collection)
+    cc_render.display_name = "multiple streamlines"
+    osmesa_fake_amr.scene.data_objects.append(curve_collection)
+    osmesa_fake_amr.scene.components.append(cc_render)
+
+    image_store(osmesa_fake_amr)
+
+    CurveCollection

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -62,6 +62,8 @@ def test_snapshots(osmesa_fake_amr, image_store):
     image_store(osmesa_fake_amr)
     osmesa_fake_amr.scene.components[0].render_method = "transfer_function"
     image_store(osmesa_fake_amr)
+    osmesa_fake_amr.scene.components[0]._recompile_shader()
+    image_store(osmesa_fake_amr)
 
 
 def test_slice(osmesa_fake_amr, image_store):

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -128,23 +128,28 @@ def test_curves(osmesa_fake_amr, image_store):
 
     curved = CurveData()
     x1d = np.linspace(0, 1, 10)
-    xyz = np.column_stack([x1d, x1d, x1d])
+    xyz = np.column_stack([x1d, x1d, np.zeros((10,))])
     curved.add_data(xyz)
-    curve_render = CurveRendering(data=curved, curve_rgba=(1.0, 0.0, 0.0, 1.0))
+    curve_render = CurveRendering(
+        data=curved, curve_rgba=(1.0, 0.0, 0.0, 1.0), line_width=4
+    )
     curve_render.display_name = "single streamline"
     osmesa_fake_amr.scene.data_objects.append(curved)
     osmesa_fake_amr.scene.components.append(curve_render)
+    image_store(osmesa_fake_amr)
 
     curve_collection = CurveCollection()
-    curve_collection.add_curve(xyz * 2.0)
-    curve_collection.add_curve(xyz * 3.0)
+    xyz = np.column_stack([x1d, np.zeros((10,)), x1d])
+    curve_collection.add_curve(xyz)
+    xyz = np.column_stack([np.zeros((10,)), x1d, x1d])
+    curve_collection.add_curve(xyz)
     curve_collection.add_data()  # call add_data() after done adding curves
 
-    cc_render = CurveCollectionRendering(data=curve_collection)
+    cc_render = CurveCollectionRendering(
+        data=curve_collection, curve_rgb=(0.2, 0.2, 0.2, 1.0), line_width=4
+    )
     cc_render.display_name = "multiple streamlines"
     osmesa_fake_amr.scene.data_objects.append(curve_collection)
     osmesa_fake_amr.scene.components.append(cc_render)
 
     image_store(osmesa_fake_amr)
-
-    CurveCollection


### PR DESCRIPTION
This adds a test for the curve rendering and fixes a traitlets deprecation warning in a few spots (there are likely additional spots missed by this PR). 

Here's an example of the deprecation warning for reference: 
```
yt_idv/scene_components/curves.py:17
  /home/chavlin/src/yt_general/yt_idv/yt_idv/scene_components/curves.py:17: DeprecationWarning: metadata {'trait': <traitlets.traitlets.CFloat object at 0x7fd876edab20>} was set from the constructor. With traitlets 4.1, metadata should be set using the .tag() method, e.g., Int().tag(key1='value1', key2='value2')
    curve_rgba = traitlets.Tuple((1.0, 1.0, 1.0, 1.0), trait=traitlets.CFloat())
```