### PR TITLE
set PYOPENGL_PLATFORM before opengl imports

### DIFF
--- a/yt_idv/rendering_contexts/__init__.py
+++ b/yt_idv/rendering_contexts/__init__.py
@@ -1,7 +1,5 @@
 import os
 
-import OpenGL.error
-
 
 def render_context(engine="pyglet", **kwargs):
     """
@@ -18,6 +16,13 @@ def render_context(engine="pyglet", **kwargs):
     RenderingContext
 
     """
+
+    # PYOPENGL_PLATFORM must be set before any opengl imports
+    if engine in ("osmesa", "egl"):
+        os.environ["PYOPENGL_PLATFORM"] = engine
+
+    import OpenGL.error
+
     if engine == "pyglet":
         from .pyglet_context import PygletRenderingContext
 
@@ -35,12 +40,10 @@ def render_context(engine="pyglet", **kwargs):
                 raise Exception(extramsg) from oee
             raise oee
     elif engine == "osmesa":
-        os.environ["PYOPENGL_PLATFORM"] = "osmesa"
         from .osmesa_context import OSMesaRenderingContext
 
         return OSMesaRenderingContext(**kwargs)
     elif engine == "egl":
-        os.environ["PYOPENGL_PLATFORM"] = "egl"
         from .egl_context import EGLRenderingContext
 
         return EGLRenderingContext(**kwargs)

--- a/yt_idv/tests/conftest.py
+++ b/yt_idv/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+
+
+def pytest_configure(config):
+    # this will get run before all tests, before collection and
+    # any opengl imports that happen within test files.
+    os.environ["PYOPENGL_PLATFORM"] = "osmesa"

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -14,11 +14,6 @@ from yt_idv.scene_components.curves import CurveCollectionRendering, CurveRender
 from yt_idv.scene_data.curve import CurveCollection, CurveData
 
 
-@pytest.fixture(autouse=True)
-def pyopengl_setup(monkeypatch):
-    monkeypatch.setenv("PYOPENGL_PLATFORM", "osmesa")
-
-
 @pytest.fixture()
 def osmesa_fake_amr():
     """Return an OSMesa context that has a "fake" AMR dataset added, with "radius"


### PR DESCRIPTION
Closes #144 and also partly addresses #148 -- switching to headless rendering context now works as expected without having to manually set the PYOPENGL_PLATFORM environment variable. 

I also switched how pytest sets PYOPENGL_PLATFORM since the monkeypatch was not having an effect (due to all the imports at the top of`test_yt_idv.py`. pytest now runs for me locally without having to set `PYOPENGL_PLATFORM`.  