### PR TITLE
Add cmyt cmaps too! 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ keywords = yt_idv
 packages = find:
 install_requires =
     Click>=7.0
+    cmyt
     imgui>=1.2.0
     matplotlib>=3.0
     numpy>=1.18.0

--- a/yt_idv/_cmyt_utilities.py
+++ b/yt_idv/_cmyt_utilities.py
@@ -1,0 +1,13 @@
+import cmyt
+from matplotlib.colors import Colormap
+
+# we want to display colormap name then cmyt for sorting purposes
+cmyt_names = [
+    f"{cm}.cmyt" for cm in dir(cmyt) if isinstance(getattr(cmyt, cm), Colormap)
+]
+
+
+def validate_cmyt_name(cm):
+    if cm.endswith(".cmyt"):
+        return "cmyt." + cm.split(".")[0]
+    return cm

--- a/yt_idv/opengl_support.py
+++ b/yt_idv/opengl_support.py
@@ -24,6 +24,7 @@ from OpenGL import GL
 # Set up a mapping from numbers to names
 from yt.utilities.math_utils import get_scale_matrix, get_translate_matrix
 
+from yt_idv._cmyt_utilities import validate_cmyt_name
 from yt_idv.constants import bbox_vertices
 
 const_types = (
@@ -221,7 +222,7 @@ class ColormapTexture(Texture1D):
     @traitlets.validate("colormap_name")
     def _validate_name(self, proposal):
         try:
-            plt.get_cmap(proposal["value"])
+            plt.get_cmap(validate_cmyt_name(proposal["value"]))
         except ValueError:
             raise traitlets.TraitError(
                 "Colormap name needs to be known by" "matplotlib"
@@ -230,7 +231,7 @@ class ColormapTexture(Texture1D):
 
     @traitlets.observe("colormap_name")
     def _observe_colormap_name(self, change):
-        cmap = plt.get_cmap(change["new"])
+        cmap = plt.get_cmap(validate_cmyt_name(change["new"]))
         cmap_vals = np.array(cmap(np.linspace(0, 1, 256)), dtype="f4")
         self.data = cmap_vals
 

--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -2,6 +2,7 @@ import numpy as np
 import traitlets
 from OpenGL import GL
 
+from yt_idv._cmyt_utilities import cmyt_names
 from yt_idv.constants import FULLSCREEN_QUAD
 from yt_idv.gui_support import add_popup_help
 from yt_idv.opengl_support import (
@@ -20,7 +21,9 @@ from yt_idv.shader_objects import (
 
 _cmaps = ["arbre", "viridis", "magma", "doom", "cividis", "plasma", "RdBu", "coolwarm"]
 _cmaps += [f"{_}_r" for _ in _cmaps]
-_cmaps.sort()
+# add in all the cmyt colormaps too! this will include the reversed maps too.
+_cmaps += cmyt_names
+_cmaps.sort(key=lambda v: v.lower())
 _buffers = ["frame", "depth"]
 
 


### PR DESCRIPTION
Followup to and based off #154, this adds the cmyt colormaps. To use the colormaps, they have to have the 'cmyt.' prefix (e.g., `'cmyt.dusk'`, `'cmyt.algae'`), but I didn't like how it resulted in grouping all the `cmyt` colormaps in the list alphabetically, I think it's more natural to sort without the prefix. So I added a bit of logic so that they end up in the list as `'dusk.cmyt'`, `'algae.cmyt'`, etc with some validation to flip it around when actually fetching the colormap from matplotlib. 

also added cmyt as an explicit dependency since i'm importing it in the changes here even though yt installs it. 

also also adjusted the sorting of colormap names to be case insensitive. 