### PR TITLE
fix extras deprecation warning

### DIFF
--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import yt
 import yt.testing
-from pytest_html import extras
+from pytest_html import extras as html_extras
 
 import yt_idv
 from yt_idv import shader_objects
@@ -39,13 +39,13 @@ def osmesa_empty():
 
 
 @pytest.fixture()
-def image_store(request, extra, tmpdir):
+def image_store(request, extras, tmpdir):
     def _snap_image(rc):
         image = rc.run()
         img = yt.write_bitmap(image, None)
         content = base64.b64encode(img).decode("ascii")
-        extra.append(extras.png(content))
-        extra.append(extras.html("<br clear='all'/>"))
+        extras.append(html_extras.png(content))
+        extras.append(html_extras.html("<br clear='all'/>"))
 
     return _snap_image
 


### PR DESCRIPTION
Fixes the following deprecation warning:

```
/home/chavlin/.pyenv/versions/3.10.11/envs/yt_idv_310/lib/python3.10/site-packages/pytest_html/fixtures.py:23: DeprecationWarning: The 'extra' fixture is deprecated and will be removed in a future release, use 'extras' instead.
```