### PR TITLE
add camera.set_position to TrackballCamera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,8 +111,9 @@ ENV/
 .vscode/
 .idea/
 
-# Screenshots
+# Screenshots and examples
 snap_*.png
+examples/*.png
 
 # pytest outputs
 report.html

--- a/examples/amr_osmesa.py
+++ b/examples/amr_osmesa.py
@@ -15,3 +15,7 @@ rc.scene.camera.move_forward(1.5)
 
 image = rc.run()
 yt.write_bitmap(image, "step2.png")
+
+rc.scene.camera.set_position([1.0, 1.5, 3.0])
+image = rc.run()
+yt.write_bitmap(image, "step3_set_position.png")

--- a/yt_idv/cameras/trackball_camera.py
+++ b/yt_idv/cameras/trackball_camera.py
@@ -86,3 +86,7 @@ class TrackballCamera(BaseCamera):
 
     def _compute_matrices(self):
         pass
+
+    def set_position(self, pos):
+        self.position = pos
+        self._update_matrices()

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -62,6 +62,15 @@ def test_snapshots(osmesa_fake_amr, image_store):
     image_store(osmesa_fake_amr)
 
 
+def test_camera_position(osmesa_fake_amr, image_store):
+    """Check that we can update the camera position"""
+    vm = osmesa_fake_amr.scene.camera.view_matrix
+    osmesa_fake_amr.scene.camera.set_position([0.5, 2.0, 3.0])
+    # check that the view matrix has changed
+    assert np.sum(np.abs(vm - osmesa_fake_amr.scene.camera.view_matrix)) > 0.0
+    image_store(osmesa_fake_amr)
+
+
 def test_depth_buffer_toggle(osmesa_fake_amr, image_store):
     osmesa_fake_amr.scene.components[0].use_db = True
     image_store(osmesa_fake_amr)


### PR DESCRIPTION
This adds a camera.set_position function so that the view_matrix will get updated when setting a position.

here's the result of the additional image i added to examples/amr_osmesa.py

![step3_set_position](https://github.com/user-attachments/assets/e759606b-ea7f-4423-a369-8b7208831dc8)
