### PR TITLE
offset the normalized block data by eps

### DIFF
--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -132,7 +132,7 @@ class BlockCollection(SceneData):
                 # blocks filled with identically 0 values will be
                 # skipped by the shader, so offset by a tiny value.
                 # see https://github.com/yt-project/yt_idv/issues/171
-                n_data += np.finfo(np.float32).eps
+                n_data[n_data == 0.0] += np.finfo(np.float32).eps
 
             data_tex = Texture3D(data=n_data)
             bitmap_tex = Texture3D(

--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -129,6 +129,10 @@ class BlockCollection(SceneData):
             # Avoid setting to NaNs
             if self.max_val != self.min_val:
                 n_data = self._normalize_by_min_max(n_data)
+                # blocks filled with identically 0 values will be
+                # skipped by the shader, so offset by a tiny value.
+                # see https://github.com/yt-project/yt_idv/issues/171
+                n_data += np.finfo(np.float32).eps
 
             data_tex = Texture3D(data=n_data)
             bitmap_tex = Texture3D(


### PR DESCRIPTION
Close #171 

This is the result of the test script from #171 on this branch:

![snap_0000](https://github.com/user-attachments/assets/663f5278-573b-4962-aa36-a946b723b667)

