### PR TITLE
update constant_rgba blend func, rm linewidth from curve render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ snap_*.png
 
 # pytest outputs
 report.html
+
+*.DS_Store
+*.swp

--- a/yt_idv/scene_components/curves.py
+++ b/yt_idv/scene_components/curves.py
@@ -13,17 +13,11 @@ class CurveRendering(SceneComponent):
 
     name = "curve_rendering"
     data = traitlets.Instance(CurveData, help="The curve data.")
-    line_width = traitlets.CFloat(1.0)
     curve_rgba = traitlets.Tuple((1.0, 1.0, 1.0, 1.0)).tag(trait=traitlets.CFloat())
     priority = 10
 
     def render_gui(self, imgui, renderer, scene):
         changed, self.visible = imgui.checkbox("Visible", self.visible)
-
-        _, line_width = imgui.slider_float("Line Width", self.line_width, 1.0, 10.0)
-        if _:
-            self.line_width = line_width
-        changed = changed or _
 
         _, newRGBa = imgui.input_float4("RGBa", *self.curve_rgba)
         if _:
@@ -35,7 +29,9 @@ class CurveRendering(SceneComponent):
     def draw(self, scene, program):
         GL.glEnable(GL.GL_CULL_FACE)
         GL.glCullFace(GL.GL_BACK)
-        GL.glLineWidth(self.line_width)
+        # note: line width != 1.0 is not supported on all platforms.
+        # see https://github.com/yt-project/yt_idv/issues/174
+        GL.glLineWidth(1.0)
         GL.glDrawArrays(GL.GL_LINE_STRIP, 0, self.data.n_vertices)
 
     def _set_uniforms(self, scene, shader_program):
@@ -55,5 +51,5 @@ class CurveCollectionRendering(CurveRendering):
     def draw(self, scene, program):
         GL.glEnable(GL.GL_CULL_FACE)
         GL.glCullFace(GL.GL_BACK)
-        GL.glLineWidth(self.line_width)
+        GL.glLineWidth(1.0)
         GL.glDrawArrays(GL.GL_LINES, 0, self.data.n_vertices)

--- a/yt_idv/shaders/shaderlist.yaml
+++ b/yt_idv/shaders/shaderlist.yaml
@@ -11,8 +11,8 @@ shader_definitions:
       info: A constant, specified RGBa value applied
       source: constant_rgba.frag.glsl
       blend_func:
-        - one
-        - one
+        - src alpha
+        - dst alpha
       blend_equation: func add
     apply_colormap:
       info:


### PR DESCRIPTION
Close #174 

Removes the linewidth option, updates the blend function for constant_rgba shader so that opacity works as expected.