### PR TITLE
Improve grid outlines render_gui, prevent colormap dialogue from showing up in all components

### DIFF
--- a/yt_idv/scene_annotations/base_annotation.py
+++ b/yt_idv/scene_annotations/base_annotation.py
@@ -2,4 +2,4 @@ from yt_idv.scene_components.base_component import SceneComponent
 
 
 class SceneAnnotation(SceneComponent):
-    pass
+    _has_colormap = False

--- a/yt_idv/scene_annotations/grid_outlines.py
+++ b/yt_idv/scene_annotations/grid_outlines.py
@@ -25,3 +25,19 @@ class GridOutlines(SceneAnnotation):
         shader_program._set_uniform("box_width", self.box_width)
         shader_program._set_uniform("box_color", np.array(self.box_color))
         shader_program._set_uniform("box_alpha", self.box_alpha)
+
+    def render_gui(self, imgui, renderer, scene):
+        changed = super().render_gui(imgui, renderer, scene)
+        _, bw = imgui.slider_float("Width", self.box_width, 0.001, 2.50)
+        if _:
+            self.box_width = bw
+        changed = changed or _
+        _, (r, g, b) = imgui.color_edit3("Color", *self.box_color)
+        if _:
+            self.box_color = (r, g, b)
+        changed = changed or _
+        _, ba = imgui.slider_float("Alpha", self.box_alpha, 0.0, 1.0)
+        if _:
+            self.box_alpha = ba
+        changed = changed or _
+        return changed

--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -32,6 +32,7 @@ class SceneComponent(traitlets.HasTraits):
     data = traitlets.Instance(SceneData)
     base_quad = traitlets.Instance(SceneData)
     name = "undefined"
+    _has_colormap = True
     priority = traitlets.CInt(0)
     visible = traitlets.Bool(True)
     use_db = traitlets.Bool(False)  # use depth buffer
@@ -105,25 +106,29 @@ class SceneComponent(traitlets.HasTraits):
 
         if imgui.button("Recompile Shader"):
             changed = self._recompile_shader()
-        _, cmap_index = imgui.listbox(
-            "Colormap", _cmaps.index(self.colormap.colormap_name), _cmaps
-        )
-        if _:
-            self.colormap.colormap_name = _cmaps[cmap_index]
-        changed = changed or _
-        _ = add_popup_help(imgui, "Select the colormap to use for the rendering.")
-        changed = changed or _
-        _, self.cmap_log = imgui.checkbox("Take log", self.cmap_log)
-        changed = changed or _
-        _ = add_popup_help(
-            imgui, "If checked, the rendering will use log-normalized values."
-        )
-        changed = changed or _
-        if imgui.button("Reset Colorbounds"):
-            self._cmap_bounds_invalid = True
-            changed = True
-        _ = add_popup_help(imgui, "Click to reset the colorbounds of the current view.")
-        changed = changed or _
+
+        if self._has_colormap:
+            _, cmap_index = imgui.listbox(
+                "Colormap", _cmaps.index(self.colormap.colormap_name), _cmaps
+            )
+            if _:
+                self.colormap.colormap_name = _cmaps[cmap_index]
+            changed = changed or _
+            _ = add_popup_help(imgui, "Select the colormap to use for the rendering.")
+            changed = changed or _
+            _, self.cmap_log = imgui.checkbox("Take log", self.cmap_log)
+            changed = changed or _
+            _ = add_popup_help(
+                imgui, "If checked, the rendering will use log-normalized values."
+            )
+            changed = changed or _
+            if imgui.button("Reset Colorbounds"):
+                self._cmap_bounds_invalid = True
+                changed = True
+            _ = add_popup_help(
+                imgui, "Click to reset the colorbounds of the current view."
+            )
+            changed = changed or _
 
         if self.render_method == "isocontours":
             _ = self._render_isolayer_inputs(imgui)

--- a/yt_idv/scene_components/curves.py
+++ b/yt_idv/scene_components/curves.py
@@ -15,6 +15,7 @@ class CurveRendering(SceneComponent):
     data = traitlets.Instance(CurveData, help="The curve data.")
     curve_rgba = traitlets.Tuple((1.0, 1.0, 1.0, 1.0)).tag(trait=traitlets.CFloat())
     priority = 10
+    _has_colormap = False
 
     def render_gui(self, imgui, renderer, scene):
         changed, self.visible = imgui.checkbox("Visible", self.visible)


### PR DESCRIPTION
This adds a `render_gui` method to `GridOutlines`  (which was missing, so you couldn't adjust grid outline appearances) and adds a quick bandaid to child component drift into the base `SceneComponent`.