### PR TITLE
Use only intersected grids for GridOutline

### DIFF
--- a/yt_idv/scene_components/blocks.py
+++ b/yt_idv/scene_components/blocks.py
@@ -58,8 +58,7 @@ class BlockRendering(SceneComponent):
             from ..scene_annotations.grid_outlines import GridOutlines
             from ..scene_data.grid_positions import GridPositions
 
-            grids = self.data.data_source.ds.index.grids.tolist()
-            gp = GridPositions(grid_list=grids)
+            gp = GridPositions(grid_list=self.data.intersected_grids)
             scene.data_objects.append(gp)
             scene.components.append(GridOutlines(data=gp))
         if self.render_method == "transfer_function":

--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -140,3 +140,17 @@ class BlockCollection(SceneData):
             )
             self.texture_objects[vbo_i] = data_tex
             self.bitmap_objects[vbo_i] = bitmap_tex
+
+    _grid_id_list = None
+
+    @property
+    def grid_id_list(self):
+        # get the grids that contain all the blocks
+        if self._grid_id_list is None:
+            gl = [gid for gid, _ in self.grids_by_block.values()]
+            self._grid_id_list = np.unique(gl).tolist()
+        return self._grid_id_list
+
+    @property
+    def intersected_grids(self):
+        return [self.data_source.ds.index.grids[gid] for gid in self.grid_id_list]

--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -145,7 +145,7 @@ class BlockCollection(SceneData):
 
     @property
     def grid_id_list(self):
-        # get the grids that contain all the blocks
+        """the 0-indexed grid ids that contain all the blocks"""
         if self._grid_id_list is None:
             gl = [gid for gid, _ in self.grids_by_block.values()]
             self._grid_id_list = np.unique(gl).tolist()

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -229,3 +229,19 @@ def test_shader_programs(osmesa_empty, shader_name):
         )
         assert isinstance(colormap_fragment, shader_objects.Shader)
         _ = shader_objects.ShaderProgram(colormap_vertex, colormap_fragment)
+
+
+def test_block_collection_grid_ids():
+    rc = yt_idv.render_context("osmesa", width=1024, height=1024)
+    ds = yt.testing.fake_amr_ds()
+    wid = ds.domain_width / 20.0 / 2.0
+    c = ds.domain_center
+    reg = ds.region(c, c - wid, c + wid)
+    rc.add_scene(reg, ("stream", "Density"), no_ghost=True)
+
+    block_coll = rc.scene.data_objects[0]
+    gl = block_coll.grid_id_list
+    assert len(gl) < len(ds.index.grids)
+    grids = block_coll.intersected_grids
+    assert len(grids) == len(gl)
+    rc.osmesa.OSMesaDestroyContext(rc.context)


### PR DESCRIPTION
This PR adds a couple attributes to the `BlockCollection`:

* `grid_id_list` is a list of grid ids that contain all the blocks
* `intersected_grids` returns a list of the yt ds grid objects for those ids

And then changes the GUI's `Add Grid Outline` button to only add the intersected grids.

As a result, you only get the outlines for the grids that include data

```
import yt
import yt_idv

ds = yt.load_sample("IsolatedGalaxy")
rc = yt_idv.render_context(height=800, width=800, gui=True)

c = ds.domain_center.copy()
le = c - ds.domain_width/20.
re = c + ds.domain_width/20.
reg = ds.region(c, le, re)
sg = rc.add_scene(reg, "density", no_ghost=True)
rc.run()
```
![snap_0000](https://github.com/user-attachments/assets/ae1b4a45-fe25-4041-9f29-5c68d3498baf)

Note: if it's better to include all grids by default, I could instead refactor GridOutlines  to accept a list of the intersected grids and then have a toggle in the GridOutlines component to switch between.

Close #178  