### PR TITLE
Displaying camera dictionary, updating from dict

### DIFF
--- a/yt_idv/cameras/base_camera.py
+++ b/yt_idv/cameras/base_camera.py
@@ -117,3 +117,16 @@ class BaseCamera(traitlets.HasTraits):
         shader_program._set_uniform("near_plane", self.near_plane)
         shader_program._set_uniform("far_plane", self.far_plane)
         shader_program._set_uniform("camera_pos", self.position)
+
+    def dict(self):
+        attrs = [
+            "position",
+            "focus",
+            "up",
+            "fov",
+            "near_plane",
+            "far_plane",
+            "aspect_ratio",
+            "orientation",
+        ]
+        return {ky: getattr(self, ky) for ky in attrs}

--- a/yt_idv/cameras/base_camera.py
+++ b/yt_idv/cameras/base_camera.py
@@ -119,14 +119,27 @@ class BaseCamera(traitlets.HasTraits):
         shader_program._set_uniform("camera_pos", self.position)
 
     def dict(self):
-        attrs = [
+        # array attributes
+        array_attrs = [
             "position",
             "focus",
             "up",
+            "orientation",
+        ]
+        cdict = {ky: getattr(self, ky).tolist() for ky in array_attrs}
+
+        attrs = [
             "fov",
             "near_plane",
             "far_plane",
             "aspect_ratio",
-            "orientation",
         ]
-        return {ky: getattr(self, ky) for ky in attrs}
+        for ky in attrs:
+            cdict[ky] = getattr(self, ky)
+
+        return cdict
+
+    def update(self, **kwargs):
+        with self.hold_traits(self._compute_matrices):
+            for ky, val in kwargs.items():
+                setattr(self, ky, val)

--- a/yt_idv/simple_gui.py
+++ b/yt_idv/simple_gui.py
@@ -136,6 +136,10 @@ class SimpleGUI:
                 changed = True
         if changed:
             scene.camera._update_matrices()
+
+        if imgui.button("print camera to console"):
+            print(scene.camera.dict())
+
         imgui.tree_pop()
         return changed
 

--- a/yt_idv/simple_gui.py
+++ b/yt_idv/simple_gui.py
@@ -138,7 +138,9 @@ class SimpleGUI:
             scene.camera._update_matrices()
 
         if imgui.button("print camera to console"):
-            print(scene.camera.dict())
+            import json
+
+            print(json.dumps(scene.camera.dict(), indent=4))
 
         imgui.tree_pop()
         return changed

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 import yt
 import yt.testing
+from numpy.testing import assert_equal
 from pytest_html import extras as html_extras
 
 import yt_idv
@@ -229,3 +230,15 @@ def test_shader_programs(osmesa_empty, shader_name):
         )
         assert isinstance(colormap_fragment, shader_objects.Shader)
         _ = shader_objects.ShaderProgram(colormap_vertex, colormap_fragment)
+
+
+def test_camera_dict_update(osmesa_fake_amr):
+    pos = [0.5, 2.0, 3.0]
+    osmesa_fake_amr.scene.camera.set_position(pos)
+
+    cdict = osmesa_fake_amr.scene.camera.dict()
+    assert_equal(cdict["position"], pos)
+
+    osmesa_fake_amr.scene.camera.set_position([4.0, 4.0, 4])
+    osmesa_fake_amr.scene.camera.update(**cdict)
+    assert_equal(osmesa_fake_amr.scene.camera.position, pos)


### PR DESCRIPTION
This adds a simple way to display the camera state from the GUI, which let's you, for example, set up a scene, print the camera state and then copy that into a script for headless rendering with the same view. 

https://github.com/user-attachments/assets/b043618f-d5fa-41e2-b946-0592fe87c30d

