### PR TITLE
allow configurable constant color for constant shader

### DIFF
--- a/yt_idv/shaders/shaderlist.yaml
+++ b/yt_idv/shaders/shaderlist.yaml
@@ -14,6 +14,13 @@ shader_definitions:
         - src alpha
         - dst alpha
       blend_equation: func add
+    constant_rgba_no_blend:
+      info: A constant, specified RGBa value applied without blending.
+      source: constant_rgba.frag.glsl
+      blend_func:
+        - one
+        - zero
+      blend_equation: func add
     apply_colormap:
       info:
         A second pass fragment shader used to apply a colormap to the result of
@@ -243,9 +250,9 @@ component_shaders:
       description: Constant Color
       first_vertex: grid_position
       first_geometry: grid_expand
-      first_fragment: constant
+      first_fragment: constant_rgba_no_blend
       second_vertex: passthrough
-      second_fragment: apply_colormap
+      second_fragment: passthrough
       coordinate_systems: [cartesian, spherical]
   octree_block_rendering:
     default_value: max_intensity


### PR DESCRIPTION
This adjusts the `'constant'` component shader to set a specific rgba value and have an rgba entry input pop up in the GUI when the constant render method is selected. 

<img width="751" alt="Screenshot 2025-05-27 at 11 43 45 AM" src="https://github.com/user-attachments/assets/e3f9fbf5-bffd-4e4f-9bc5-00e140c63afe" />


It also moves the block outline and grid outline buttons to below the render_method gui components that pop up depending on the selected render_method

