### PR TITLE
add `TrackballCamera.from_dataset(ds)`, add example of manual `SceneGraph` contstruction

### DIFF
--- a/examples/manual_amr_scene_graph.py
+++ b/examples/manual_amr_scene_graph.py
@@ -1,0 +1,23 @@
+"""
+Example demonstrating manual construction of a SceneGraph with a BlockCollection
+"""
+
+import yt
+
+import yt_idv
+from yt_idv.cameras.trackball_camera import TrackballCamera
+from yt_idv.scene_components.blocks import BlockRendering
+from yt_idv.scene_data.block_collection import BlockCollection
+from yt_idv.scene_graph import SceneGraph
+
+ds = yt.load_sample("IsolatedGalaxy")
+rc = yt_idv.render_context(height=800, width=800, gui=True)
+
+c = TrackballCamera.from_dataset(ds)
+rc.scene = SceneGraph(camera=c)
+block_coll = BlockCollection(data_source=ds.all_data())
+block_coll.add_data(("gas", "density"), no_ghost=True)
+rc.scene.data_objects.append(block_coll)
+rc.scene.components.append(BlockRendering(data=block_coll))
+
+rc.run()

--- a/yt_idv/cameras/trackball_camera.py
+++ b/yt_idv/cameras/trackball_camera.py
@@ -90,3 +90,34 @@ class TrackballCamera(BaseCamera):
     def set_position(self, pos):
         self.position = pos
         self._update_matrices()
+
+    @staticmethod
+    def from_dataset(ds):
+        center, pos, near_plane = _get_camera_for_ds_geometry(ds)
+
+        c = TrackballCamera(position=pos, focus=center, near_plane=near_plane)
+        c.update_orientation(0, 0, 0, 0)
+        return c
+
+
+def _get_camera_for_ds_geometry(ds):
+
+    if str(ds.geometry) == "spherical":
+        # dummy values here, will get updated after data is loaded
+        # and the cartesian bounds are available
+        center = np.array([0.5, 0.5, 0.5])
+        wid = np.array([1.0, 1.0, 1.0])
+        pos = center + 1.5 * wid
+        dx_aprox = wid[0] / np.max(ds.domain_dimensions)
+        near_plane = 3.0 * dx_aprox
+        near_plane = max(near_plane, 1e-5)
+    elif str(ds.geometry) == "cartesian":
+        center = ds.domain_center
+        pos = center + 1.5 * ds.domain_width.in_units("unitary")
+        near_plane = 3.0 * ds.index.get_smallest_dx().min().in_units("unitary").d
+        near_plane = max(near_plane, 1e-5)
+    else:
+        raise NotImplementedError(
+            "Only cartesian and spherical geometries are supported at present."
+        )
+    return center, pos, near_plane

--- a/yt_idv/scene_graph.py
+++ b/yt_idv/scene_graph.py
@@ -1,6 +1,5 @@
 import contextlib
 
-import numpy as np
 import traitlets
 from OpenGL import GL
 from yt.data_objects.static_output import Dataset
@@ -260,11 +259,7 @@ class SceneGraph(traitlets.HasTraits):
         else:
             ds, data_source = ds.ds, ds
 
-        center, pos, near_plane = _get_camera_for_geometry(data_source, ds)
-
-        c = TrackballCamera(position=pos, focus=center, near_plane=near_plane)
-        c.update_orientation(0, 0, 0, 0)
-
+        c = TrackballCamera.from_dataset(ds)
         scene = SceneGraph(camera=c)
 
         if field is not None:
@@ -289,26 +284,3 @@ def _update_scene_camera_for_geometry(ds, scene):
             camera: TrackballCamera = scene.camera
             camera.update(focus=center, position=pos, near_plane=near_plane)
             camera._update_matrices()
-
-
-def _get_camera_for_geometry(data_source, ds):
-
-    if str(ds.geometry) == "spherical":
-        # dummy values here, will get updated after data is loaded
-        # and the cartesian bounds are available
-        center = np.array([0.5, 0.5, 0.5])
-        wid = np.array([1.0, 1.0, 1.0])
-        pos = center + 1.5 * wid
-        dx_aprox = wid[0] / np.max(ds.domain_dimensions)
-        near_plane = 3.0 * dx_aprox
-        near_plane = max(near_plane, 1e-5)
-    elif str(ds.geometry) == "cartesian":
-        center = ds.domain_center
-        pos = center + 1.5 * ds.domain_width.in_units("unitary")
-        near_plane = 3.0 * ds.index.get_smallest_dx().min().in_units("unitary").d
-        near_plane = max(near_plane, 1e-5)
-    else:
-        raise NotImplementedError(
-            "Only cartesian and spherical geometries are supported at present."
-        )
-    return center, pos, near_plane

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -8,8 +8,12 @@ from numpy.testing import assert_equal
 
 import yt_idv
 from yt_idv import shader_objects
+from yt_idv.cameras.trackball_camera import TrackballCamera
+from yt_idv.scene_components.blocks import BlockRendering
 from yt_idv.scene_components.curves import CurveCollectionRendering, CurveRendering
+from yt_idv.scene_data.block_collection import BlockCollection
 from yt_idv.scene_data.curve import CurveCollection, CurveData
+from yt_idv.scene_graph import SceneGraph
 
 
 @pytest.fixture()
@@ -242,4 +246,18 @@ def test_block_collection_grid_ids():
     assert len(gl) < len(ds.index.grids)
     grids = block_coll.intersected_grids
     assert len(grids) == len(gl)
+    rc.osmesa.OSMesaDestroyContext(rc.context)
+
+
+def test_manual_scene_graph(image_store):
+    rc = yt_idv.render_context("osmesa", width=1024, height=1024)
+    ds = yt.testing.fake_amr_ds()
+
+    c = TrackballCamera.from_dataset(ds)
+    rc.scene = SceneGraph(camera=c)
+    rc.scene.data_objects.append(BlockCollection(data_source=ds.all_data()))
+    rc.scene.data_objects[-1].add_data(("stream", "Density"), no_ghost=True)
+    rc.scene.components.append(BlockRendering(data=rc.scene.data_objects[-1]))
+
+    image_store(rc)
     rc.osmesa.OSMesaDestroyContext(rc.context)


### PR DESCRIPTION
Been working on some figures for the spherical vol rendering paper and wanted to manually build a SceneGraph in order to more easily modify some `BlockCollection` attributes. This PR adds an example of how to do that and also refactors the default camera initialization to  its own method `TrackballCamera.from_dataset(ds)` to make that easier.