### PR TITLE
only introspect shaders when np<2.3.0 for now

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -24,6 +24,8 @@ jobs:
       run: python -m pip install --upgrade pip
     - name: Setup yt_idv
       run: python -m pip install -e .[test]
+    - name: List final env
+      run: python -m pip list
     - name: Run Tests
       env:
           PYOPENGL_PLATFORM: osmesa

--- a/yt_idv/shader_objects.py
+++ b/yt_idv/shader_objects.py
@@ -9,9 +9,11 @@ import os
 from collections import OrderedDict
 from typing import List, Optional, Tuple
 
+import numpy as np
 import traitlets
 import yaml
 from OpenGL import GL
+from packaging.version import Version
 from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import (
     YTInvalidShaderType,
@@ -151,7 +153,9 @@ class ShaderProgram:
         fragment_shader.delete_shader()
         if geometry_shader is not None:
             geometry_shader.delete_shader()
-        self.introspect()
+        if Version(np.__version__) < Version("2.3.0"):
+            # see https://github.com/yt-project/yt_idv/pull/201
+            self.introspect()
 
     def introspect(self):
         if self.program is None:


### PR DESCRIPTION
temporary fix for #202 : only `introspect` at np<2.3.0. Should not affect actual functionality. 