### PR TITLE
add unweighted projection render method

### DIFF
--- a/examples/amr_render_cells.py
+++ b/examples/amr_render_cells.py
@@ -1,0 +1,13 @@
+import yt
+
+import yt_idv
+
+ds = yt.load_sample("Enzo_64")
+
+rc = yt_idv.render_context(height=800, width=800, gui=True)
+sg = rc.add_scene(ds, ("index", "ones"), no_ghost=True)
+
+sg.components[0].cmap_log = False
+sg.components[0].render_method = "sum_projection"
+
+rc.run()

--- a/yt_idv/shaders/shaderlist.yaml
+++ b/yt_idv/shaders/shaderlist.yaml
@@ -104,6 +104,17 @@ shader_definitions:
         - one
         - one
       blend_equation: func add
+    sum_projection:
+      info:
+        A first pass fragment shader that performs unweighted integration of the
+        data along the line of sight. See :ref:`projection-types` for more information.
+      source:
+        - ray_tracing.frag.glsl
+        - sum_projection.frag.glsl
+      blend_func:
+        - one
+        - one
+      blend_equation: func add
     text_overlay:
       info: A simple text overlay shader
       source: textoverlay.frag.glsl
@@ -214,6 +225,14 @@ component_shaders:
       first_vertex: grid_position
       first_geometry: grid_expand
       first_fragment: projection
+      second_vertex: passthrough
+      second_fragment: apply_colormap
+      coordinate_systems: [cartesian, spherical]
+    sum_projection:
+      description: Unweighted sum
+      first_vertex: grid_position
+      first_geometry: grid_expand
+      first_fragment: sum_projection
       second_vertex: passthrough
       second_fragment: apply_colormap
       coordinate_systems: [cartesian, spherical]

--- a/yt_idv/shaders/sum_projection.frag.glsl
+++ b/yt_idv/shaders/sum_projection.frag.glsl
@@ -1,0 +1,18 @@
+bool sample_texture(vec3 tex_curr_pos, inout vec4 curr_color, float tdelta,
+                    float t, vec3 dir) {
+
+    vec3 offset_pos = get_offset_texture_position(ds_tex[0], tex_curr_pos);
+    vec3 tex_sample = texture(ds_tex[0], offset_pos).rgb;
+    vec3 offset_bmap_pos = get_offset_texture_position(bitmap_tex, tex_curr_pos);
+    float map_sample = texture(bitmap_tex, offset_bmap_pos).r;
+    if (map_sample > 0.0) {
+        float val = tex_sample.r + curr_color.r;
+        curr_color = vec4(val, val, val, 1.0);
+    }
+    return bool(map_sample > 0.0);
+}
+
+vec4 cleanup_phase(in vec4 curr_color, in vec3 dir, in float t0, in float t1)
+{
+  return vec4(curr_color);
+}


### PR DESCRIPTION
I'm not positive this should actually be merged, but thought it was worth documenting in a PR... 

This PR adds an unweighted projection, which let's you visualize grid cells when projecting ('index', 'ones') in interesting ways? 

e.g., 

![snap_0000](https://github.com/user-attachments/assets/5f227ec6-ac2c-436d-8357-343c35730841)

some angles have some odd artifacts though:


![snap_0001](https://github.com/user-attachments/assets/fdb6c989-06a6-4829-8cdb-85bba7e02561)
