### PR TITLE
fix: resolve python flake8 compatibility crash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,12 @@ repos:
     - id: pyupgrade
       args: [--py37-plus]
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
     - id: black-jupyter
 
 -   repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
+    rev: 9.0.0b1
     hooks:
     - id: isort
       name: isort (python)
@@ -40,9 +40,8 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: [
-        flake8-bugbear==22.7.1,
-        flake8-logging-format==0.8.1,
-        flake8-2020==1.6.1,
+        flake8-bugbear==25.11.29,
+        flake8-2020==1.8.1,
       ]
 -   repo: https://github.com/asottile/blacken-docs
     rev: 1.20.0
@@ -62,6 +61,5 @@ repos:
     - id: nbqa-flake8
       args: [--extend-ignore=E402]
       additional_dependencies: [
-        flake8-bugbear==22.7.1,
-        flake8-logging-format==0.8.1,
+        flake8-bugbear==25.11.29,
       ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     Click>=7.0
     cmyt
     imgui>=1.2.0
-    matplotlib>=3.11.0
+    matplotlib>=3.0,<3.10
     numpy>=1.18.0
     pyOpenGL>=3.1.5
     pyglet>=2.0.dev0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     Click>=7.0
     cmyt
     imgui>=1.2.0
-    matplotlib>=3.0
+    matplotlib>=3.11.0
     numpy>=1.18.0
     pyOpenGL>=3.1.5
     pyglet>=2.0.dev0


### PR DESCRIPTION
#231
#230 

- Updated black and isort hooks.
- Upgraded flake8-bugbear and flake8-2020 to fix crashes on Python 3.14.
- Removed flake8-logging-format since it's incompatible with modern environments that lack pkg_resources.