### PR TITLE
cache osmesa apt packages in CI

### DIFF
--- a/.github/actions/install-osmesa/action.yml
+++ b/.github/actions/install-osmesa/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Restore cached apt packages
       id: apt-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: /tmp/osmesa-debs
         key: osmesa-debs-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ inputs.packages }}

--- a/.github/actions/install-osmesa/action.yml
+++ b/.github/actions/install-osmesa/action.yml
@@ -1,0 +1,49 @@
+name: Install OSMesa
+description: >
+  Install the OSMesa development headers used for offscreen rendering, caching
+  the downloaded .deb files so runs do not have to hit the Ubuntu archives.
+
+inputs:
+  packages:
+    description: Space separated list of apt packages to install.
+    required: false
+    default: libosmesa6-dev
+
+runs:
+  using: composite
+  steps:
+    - name: Restore cached apt packages
+      id: apt-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/osmesa-debs
+        key: osmesa-debs-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ inputs.packages }}
+
+    - name: Download apt packages
+      if: steps.apt-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+      run: |
+        set -euo pipefail
+        sudo mkdir -p /tmp/osmesa-debs/partial
+        sudo apt-get update
+        sudo apt-get install -y --download-only \
+          -o Dir::Cache::archives=/tmp/osmesa-debs $PACKAGES
+        sudo rm -rf /tmp/osmesa-debs/partial /tmp/osmesa-debs/lock
+        sudo chown -R "$(id -u):$(id -g)" /tmp/osmesa-debs
+
+    - name: Install apt packages
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        debs=(/tmp/osmesa-debs/*.deb)
+        if [ ${#debs[@]} -gt 0 ]; then
+          sudo dpkg --install "${debs[@]}"
+        else
+          echo "nothing to install, the runner image already provides $PACKAGES"
+        fi
+        dpkg-query -W $PACKAGES

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/install-osmesa"
     schedule:
       interval: "weekly" # Options: daily, weekly, monthly
     open-pull-requests-limit: 10

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,9 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v7
     - name: Install osmesa
-      run: |
-        sudo apt-get update && sudo apt-get upgrade
-        sudo apt-get install libosmesa6-dev
+      uses: ./.github/actions/install-osmesa
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Setup yt_idv

--- a/.github/workflows/check-min-numpy.yaml
+++ b/.github/workflows/check-min-numpy.yaml
@@ -17,9 +17,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v7
     - name: Install osmesa
-      run: |
-        sudo apt-get update && sudo apt-get upgrade
-        sudo apt-get install libosmesa6-dev
+      uses: ./.github/actions/install-osmesa
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - name: Setup yt_idv


### PR DESCRIPTION
An experiment with cacheing. 

Move the osmesa install into a composite action shared by the test workflows. The downloaded .deb files are cached and keyed on the runner image, so a cache hit installs them with dpkg instead of fetching from the Ubuntu archives.