### PR TITLE
Fix invisible imgui overlay on macOS with pyglet >= 2.1

### DIFF
--- a/yt_idv/simple_gui.py
+++ b/yt_idv/simple_gui.py
@@ -3,7 +3,6 @@ import math
 import imgui
 import matplotlib.pyplot as plt
 import numpy as np
-from imgui.integrations.pyglet import create_renderer
 from yt.visualization.image_writer import write_bitmap, write_image
 
 from .opengl_support import Texture2D
@@ -17,6 +16,11 @@ class SimpleGUI:
     draw = False
 
     def __init__(self, window):
+        # import pyglet integration here rather than at module scope to avoid
+        # creating a pyglet shadow window on import, which requires a display.
+        # Allows us to run headless tests without a display.
+        from imgui.integrations.pyglet import create_renderer
+
         self.window = window
         self.context = imgui.create_context()
         self.renderer = create_renderer(window)

--- a/yt_idv/simple_gui.py
+++ b/yt_idv/simple_gui.py
@@ -20,6 +20,7 @@ class SimpleGUI:
         self.window = window
         self.context = imgui.create_context()
         self.renderer = create_renderer(window)
+        self._fix_hidpi_scaling(window)
         self.snapshot_count = 0
         self.snapshot_format = r"snap_{count:04d}.png"
         data = plt.get_cmap("viridis")(np.mgrid[0.0:1.0:256j]).reshape((-1, 1, 4))
@@ -31,6 +32,32 @@ class SimpleGUI:
         )
         data = (data[:, :, :4] * 255).astype("u1")
         self.colormap = Texture2D(data=data, boundary_x="clamp", boundary_y="clamp")
+
+    def _fix_hidpi_scaling(self, window):
+        # Reconcile imgui's notion of display size with pyglet's.
+
+        io = self.renderer.io
+        window_size = window.get_size()
+        fb_size = window.get_framebuffer_size()
+
+        # Avoid division by zero if window is minimized or zero-sized
+        if not all(window_size):
+            return
+
+        # pyglet 2.1 changed scale definitions, causing retina display clipping;
+        # recalculate true framebuffer scale
+        # Note: This is a no-op on Linux and pyglet <= 2.0 where get_pixel_ratio()
+        # already equals fb_size / window_size
+        io.display_size = window_size
+        io.display_fb_scale = (
+            fb_size[0] / window_size[0],
+            fb_size[1] / window_size[1],
+        )
+
+        # Scale font size up when imgui falls back to using raw physical pixels
+        ui_scale = window.get_pixel_ratio() / io.display_fb_scale[0]
+        if ui_scale != 1.0:
+            io.font_global_scale = ui_scale
 
     def render(self, scene):
         imgui.new_frame()

--- a/yt_idv/tests/test_simple_gui.py
+++ b/yt_idv/tests/test_simple_gui.py
@@ -1,0 +1,63 @@
+"""Tests for the imgui overlay helpers in `yt_idv.simple_gui`."""
+
+import types
+
+import pytest
+
+
+class _FakeWindow:
+    """Stand-in for a pyglet window reporting the sizes we care about."""
+
+    def __init__(self, size, framebuffer_size, pixel_ratio):
+        self._size = size
+        self._framebuffer_size = framebuffer_size
+        self._pixel_ratio = pixel_ratio
+
+    def get_size(self):
+        return self._size
+
+    def get_framebuffer_size(self):
+        return self._framebuffer_size
+
+    def get_pixel_ratio(self):
+        return self._pixel_ratio
+
+
+def _apply_fix(window):
+    from yt_idv.simple_gui import SimpleGUI
+
+    gui = types.SimpleNamespace(
+        renderer=types.SimpleNamespace(io=types.SimpleNamespace(font_global_scale=1.0))
+    )
+    SimpleGUI._fix_hidpi_scaling(gui, window)
+    return gui.renderer.io
+
+
+@pytest.mark.parametrize(
+    "size,framebuffer_size,pixel_ratio,expected_fb_scale,expected_font_scale",
+    [
+        # standard display: everything is 1:1
+        ((800, 600), (800, 600), 1.0, (1.0, 1.0), 1.0),
+        # macOS + pyglet >= 2.1: sizes are already in physical pixels, but
+        # the pixel ratio is still 2, so imgui must not scale again.
+        ((1600, 1200), (1600, 1200), 2.0, (1.0, 1.0), 2.0),
+        # pyglet <= 2.0, where get_pixel_ratio() is framebuffer/window: the
+        # scale imgui already computes is the one we compute, so this is a
+        # no-op and the font must not be touched.
+        ((800, 600), (1600, 1200), 2.0, (2.0, 2.0), 1.0),
+    ],
+)
+def test_hidpi_scaling(
+    size, framebuffer_size, pixel_ratio, expected_fb_scale, expected_font_scale
+):
+    io = _apply_fix(_FakeWindow(size, framebuffer_size, pixel_ratio))
+    assert io.display_size == size
+    assert io.display_fb_scale == expected_fb_scale
+    assert io.font_global_scale == expected_font_scale
+
+
+def test_hidpi_scaling_ignores_unrealized_window():
+    """A zero-sized window must not raise; imgui's own guess is left alone."""
+    io = _apply_fix(_FakeWindow((0, 0), (0, 0), 1.0))
+    assert not hasattr(io, "display_size")
+    assert io.font_global_scale == 1.0


### PR DESCRIPTION
Close #249 

See https://github.com/pyimgui/pyimgui/issues/395 