### PR TITLE
Extract data values from rendered block scenes

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -62,3 +62,42 @@ widget that is auto-updated when the scene runs.
 
 Note that if you have access to OSMesa but not EGL, you can use the OSMesa
 rendering context instead.
+
+---------------------------------------
+Extracting Data Values From a Rendering
+---------------------------------------
+
+With version 0.5.5, you can now extract data values from a rendering block
+collection renders for AMR data. To enable image data extraction, set
+``component.store_first_pass_fb = True`` before rendering:
+
+.. code-block:: python
+   :linenos:
+
+   import numpy as np
+   import yt
+
+   import yt_idv
+
+   ds = yt.load_sample("IsolatedGalaxy")
+
+   rc = yt_idv.render_context(height=800, width=800, gui=False)
+   sg = rc.add_scene(ds, "density", no_ghost=True)
+
+   component = rc.scene.components[0]
+   component.store_first_pass_fb = True
+   component.render_method = "max_intensity"
+
+   rc.scene.render()
+
+   rendered_plane = component.rendered_image_plane()
+
+The resulting ``rendered_plane`` object represents the rendered image plane and
+includes attributes describing the image extent in physical units as well as the
+data being rendered. The image plane extraction is currently supported for
+``render_method`` of ``max_intensity``, ``slice`` and ``projection``. For the
+case of ``projection``, the data values are the path-integrated data values along
+ray paths and will be sensitive to the camera type (which determines ray path).
+
+See :meth:`~yt_idv.scene_components.blocks.BlockRendering.rendered_image_plane` for
+more details.

--- a/examples/extracting_data_values.py
+++ b/examples/extracting_data_values.py
@@ -1,0 +1,47 @@
+"""
+Extract data values, rather than colors, from a rendered scene.
+
+Setting ``store_first_pass_fb`` on a component keeps the output of the first
+rendering pass (which holds data values) before the colormap is applied in the
+second pass. ``rendered_image_plane`` then converts that raw buffer back into
+physical units and reports the physical extent of the view.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import yt
+
+import yt_idv
+
+ds = yt.load_sample("IsolatedGalaxy")
+
+rc = yt_idv.render_context(height=800, width=800, gui=False)
+sg = rc.add_scene(ds, "density", no_ghost=True)
+
+component = rc.scene.components[0]
+component.store_first_pass_fb = True
+
+for render_method in ("max_intensity", "projection", "slice"):
+    component.render_method = render_method
+    rc.scene.render()
+
+    frb = component.rendered_image_plane()
+    print(f"{render_method}: {frb}")
+    print(f"  view is {frb.width:.3f} x {frb.height:.3f} centered on {frb.center}")
+
+    finite = frb.data[np.isfinite(frb.data)]
+    print(f"  data range: {finite.min():.3e} to {finite.max():.3e}")
+
+    plt.figure()
+    plt.imshow(
+        np.log10(frb.data.d),
+        origin="lower",
+        extent=frb.extent.in_units("kpc").d,
+        cmap="viridis",
+    )
+    plt.colorbar(label=f"log10({frb.data.units})")
+    plt.xlabel("kpc")
+    plt.ylabel("kpc")
+    plt.title(render_method)
+
+plt.show()

--- a/yt_idv/rendered_image_plane.py
+++ b/yt_idv/rendered_image_plane.py
@@ -62,17 +62,17 @@ class RenderedImagePlane:
 
     def integrate(self) -> unyt_quantity:
         """
-        Integrate the image over the plane, treating pixels as rectangles.
+            Integrate the image over the plane, treating pixels as rectangles.
 
-    Unsampled pixels (NaN) are skipped rather than treated as zeros,
-    so the result is finite when rays do not intersect the data being
-    rendered. The result is thus the integral over the sample region
-    and not the whole image plane.
+        Unsampled pixels (NaN) are skipped rather than treated as zeros,
+        so the result is finite when rays do not intersect the data being
+        rendered. The result is thus the integral over the sample region
+        and not the whole image plane.
 
-        Returns
-        -------
-        unyt_quantity
-            The integral, in the units of ``data`` times an area.
+            Returns
+            -------
+            unyt_quantity
+                The integral, in the units of ``data`` times an area.
         """
         dx, dy = self.pixel_size
         return np.nansum(self.data) * dx * dy

--- a/yt_idv/rendered_image_plane.py
+++ b/yt_idv/rendered_image_plane.py
@@ -1,0 +1,136 @@
+"""Containers and helpers for extracting data values from a rendered scene."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from unyt import unyt_array, unyt_quantity
+
+
+@dataclass(eq=False)
+class RenderedImagePlane:
+    """
+    A rendered image in data values rather than colors.
+
+    Attributes
+    ----------
+    data : unyt_array
+        The (ny, nx) image in physical units. Element ``[j, i]`` is the pixel at
+        row ``j`` (increasing along ``up``) and column ``i`` (increasing along
+        ``right``), i.e. the array is oriented for
+        ``imshow(plane.data, origin="lower", extent=plane.extent)``.
+    extent : unyt_array
+        ``(xmin, xmax, ymin, ymax)`` of the image plane, measured from ``center``
+        along the camera's right and up vectors.
+    center : unyt_array
+        The world-space position that the image is centered on (the camera focus).
+    right, up : np.ndarray
+        Unit vectors spanning the image plane, in the internal (rendering)
+        coordinate system.
+    path_length : unyt_array or None
+        For integrating render methods, the (ny, nx) distance each pixel's ray
+        traveled through the data. ``None`` for non-integrating methods.
+    """
+
+    data: unyt_array
+    extent: unyt_array
+    center: unyt_array
+    right: np.ndarray
+    up: np.ndarray
+    path_length: Optional[unyt_array] = None
+
+    @property
+    def width(self) -> unyt_quantity:
+        """The physical width of the image plane."""
+        return self.extent[1] - self.extent[0]
+
+    @property
+    def height(self) -> unyt_quantity:
+        """The physical height of the image plane."""
+        return self.extent[3] - self.extent[2]
+
+    @property
+    def dimensions(self) -> tuple:
+        """The physical ``(width, height)`` of the image plane."""
+        return (self.width, self.height)
+
+    @property
+    def pixel_size(self) -> tuple:
+        """The physical ``(dx, dy)`` of a single pixel."""
+        ny, nx = self.data.shape
+        return (self.width / nx, self.height / ny)
+
+    def integrate(self) -> unyt_quantity:
+        """
+        Integrate the image over the plane, treating pixels as rectangles.
+
+        Pixels that no ray sampled (NaN) are skipped rather than treated as
+        zeros, so the result is the integral over the rendered data alone.
+
+        Returns
+        -------
+        unyt_quantity
+            The integral, in the units of ``data`` times an area.
+        """
+        dx, dy = self.pixel_size
+        return np.nansum(self.data) * dx * dy
+
+    def __repr__(self):
+        ny, nx = self.data.shape
+        return (
+            f"RenderedImagePlane({nx} x {ny} pixels, "
+            f"{self.width} x {self.height}, units={self.data.units})"
+        )
+
+
+def image_plane_extent(projection_matrix, view_matrix, focus):
+    """
+    The extent of the viewport in the plane that contains the camera focus.
+
+    Because the camera uses a perspective projection, the region of space that
+    the image covers depends on distance from the camera: this returns the
+    extent in the plane through ``focus`` that is normal to the view direction.
+
+    Parameters
+    ----------
+    projection_matrix, view_matrix : (4, 4) arrays
+        The camera matrices, in the same row-major convention used when they are
+        handed to the shaders (``clip = projection @ view @ position``).
+    focus : (3,) array
+        The camera focus, in the internal (rendering) coordinate system.
+
+    Returns
+    -------
+    extent : (4,) np.ndarray
+        ``(xmin, xmax, ymin, ymax)`` relative to ``focus``, along the camera
+        right and up vectors.
+    right, up : (3,) np.ndarray
+        The camera right and up unit vectors.
+    """
+    view_matrix = np.asarray(view_matrix, dtype="f8")
+    pmv = np.asarray(projection_matrix, dtype="f8") @ view_matrix
+    inv_pmv = np.linalg.inv(pmv)
+    focus = np.asarray(focus, dtype="f8")
+
+    # every point in the plane normal to the view direction through the focus
+    # shares the focus values of the clip-space w and z, so the plane's corners
+    # can be found by un-projecting the corners of the normalized device cube at
+    # those values.
+    clip = pmv @ np.append(focus, 1.0)
+    w, z = clip[3], clip[2]
+
+    corners = []
+    for ndc_x in (-1.0, 1.0):
+        for ndc_y in (-1.0, 1.0):
+            corner = inv_pmv @ np.array([ndc_x * w, ndc_y * w, z, w])
+            corners.append(corner[:3] / corner[3] - focus)
+    corners = np.array(corners)
+
+    # rows 0 and 1 of the look-at matrix are the camera right and up vectors
+    right = view_matrix[0, :3]
+    up = view_matrix[1, :3]
+
+    x = corners @ right
+    y = corners @ up
+    extent = np.array([x.min(), x.max(), y.min(), y.max()])
+    return extent, right, up

--- a/yt_idv/rendered_image_plane.py
+++ b/yt_idv/rendered_image_plane.py
@@ -64,8 +64,10 @@ class RenderedImagePlane:
         """
         Integrate the image over the plane, treating pixels as rectangles.
 
-        Pixels that no ray sampled (NaN) are skipped rather than treated as
-        zeros, so the result is the integral over the rendered data alone.
+    Unsampled pixels (NaN) are skipped rather than treated as zeros,
+    so the result is finite when rays do not intersect the data being
+    rendered. The result is thus the integral over the sample region
+    and not the whole image plane.
 
         Returns
         -------

--- a/yt_idv/scene_components/base_component.py
+++ b/yt_idv/scene_components/base_component.py
@@ -57,6 +57,9 @@ class SceneComponent(traitlets.HasTraits):
     geometry_shader = ShaderTrait(allow_none=True).tag(shader_type="geometry")
     vertex_shader = ShaderTrait(allow_none=True).tag(shader_type="vertex")
     fb = traitlets.Instance(Framebuffer)
+    first_pass_fb_rgba = traitlets.Instance(np.ndarray, allow_none=True)
+    store_first_pass_fb = traitlets.Bool(False)
+    _first_pass_camera = traitlets.Dict(allow_none=True, default_value=None)
     colormap_fragment = ShaderTrait(allow_none=True).tag(shader_type="fragment")
     colormap_vertex = ShaderTrait(allow_none=True).tag(shader_type="vertex")
     colormap = traitlets.Instance(ColormapTexture)
@@ -399,6 +402,19 @@ class SceneComponent(traitlets.HasTraits):
                 with self.data.vertex_array.bind(p):
                     self.draw(scene, p)
 
+        # store a copy of the frame buffer data before we do any color-mapping
+        # so that we can extract raw data values elsewhere (e.g., get max projection
+        # data values in raw values not color-mapped values). The camera state is
+        # stored alongside it so that the physical extent of the image can be
+        # recovered even if the camera moves afterwards.
+        if self.store_first_pass_fb:
+            self.first_pass_fb_rgba = self._read_first_pass_fb()
+            self._first_pass_camera = {
+                "projection_matrix": np.array(scene.camera.projection_matrix),
+                "view_matrix": np.array(scene.camera.view_matrix),
+                "focus": np.array(scene.camera.focus),
+            }
+
         if self._cmap_bounds_invalid:
             self._reset_cmap_bounds()
 
@@ -448,6 +464,33 @@ class SceneComponent(traitlets.HasTraits):
         full_array = np.zeros(32, dtype="float32")
         full_array[: len(self.iso_layers)] = iso_vals
         return full_array
+
+    def _read_first_pass_fb(self):
+        # glReadPixels allocates its result with shape (width, height, 4) but
+        # fills it row-by-row in y, so the array has to be reshaped to be
+        # indexed as [y, x, channel] (a no-op for square viewports). Row 0 is
+        # the bottom of the image, following the OpenGL convention.
+        data = np.asarray(self.fb.data)
+        _, _, width, height = self.fb.viewport
+        return data.reshape((height, width, 4))
+
+    @property
+    def first_pass_fb_data(self):
+        """
+        The values written by the first rendering pass, before color-mapping.
+
+        A (ny, nx) array of the R channel of the stored framebuffer, or None if
+        ``store_first_pass_fb`` has not been set and the scene rendered. Note
+        that these are the raw values used internally by the shaders (min/max
+        normalized, in the internal coordinate system): use
+        ``rendered_image_plane`` for values in physical units.
+        """
+        if self.first_pass_fb_rgba is None:
+            return None
+        return self.first_pass_fb_rgba[:, :, 0]
+
+    def rendered_image_plane(self):
+        raise NotImplementedError("This method must be implemented in subclasses.")
 
     def _get_sanitized_iso_tol(self):
         # isocontour selection conditions:

--- a/yt_idv/scene_components/blocks.py
+++ b/yt_idv/scene_components/blocks.py
@@ -6,6 +6,7 @@ from OpenGL import GL
 
 from yt_idv.gui_support import add_popup_help
 from yt_idv.opengl_support import TransferFunctionTexture
+from yt_idv.rendered_image_plane import RenderedImagePlane, image_plane_extent
 from yt_idv.scene_components.base_component import SceneComponent
 from yt_idv.scene_data.block_collection import BlockCollection
 from yt_idv.shader_objects import component_shaders, get_shader_combos
@@ -184,3 +185,90 @@ class BlockRendering(SceneComponent):
     @property
     def _yt_geom_str(self):
         return self.data._yt_geom_str
+
+    def rendered_image_plane(self):
+        """
+        Extract the rendered image as data values in physical units.
+
+        Requires ``store_first_pass_fb`` to have been set to True before the
+        scene was rendered, so that the values written by the first rendering
+        pass are available (the second pass replaces them with colors).
+
+        Returns
+        -------
+        RenderedImagePlane
+            Holds the image as a unyt array along with the physical extent of
+            the view. Units depend on the render method: ``slice`` and
+            ``max_intensity`` are in the units of the rendered field, while
+            ``projection`` is in field units times a length.
+
+        Notes
+        -----
+        Values are the absolute value of the rendered field, sampled from the
+        vertex-centered data used to build the 3D textures, so they can fall
+        slightly outside the range of the cell-centered field (particularly with
+        ``no_ghost=True``).
+        """
+        if self.first_pass_fb_rgba is None:
+            raise RuntimeError(
+                "No stored framebuffer data: set store_first_pass_fb to True "
+                "and render the scene before calling rendered_image_plane."
+            )
+
+        supported = ("slice", "max_intensity", "projection")
+        if self.render_method not in supported:
+            raise NotImplementedError(
+                f"rendered_image_plane is not implemented for the "
+                f"{self.render_method} render method (supported: {supported})."
+            )
+
+        block_collection = self.data
+        ds = block_collection.data_source.ds
+        field_units = block_collection.field_units or ""
+        length_unit = block_collection.internal_length_unit
+
+        fb_data = self.first_pass_fb_rgba
+        # values accumulate in the R channel; a nonzero alpha marks the pixels
+        # that a ray actually sampled data in.
+        values = fb_data[:, :, 0].astype("float64")
+        sampled = fb_data[:, :, 3] > 0
+
+        path_length = None
+        if self.render_method == "projection":
+            # the shader integrates the normalized values,
+            #    I = sum_i n_i ds_i,  where  n_i = (|d_i| - min) / (max - min)
+            # so recovering the integral of the field values requires the total
+            # path length, L = sum_i ds_i, which the shader accumulates in G:
+            #    sum_i |d_i| ds_i = I * (max - min) + min * L
+            path_length = fb_data[:, :, 1].astype("float64")
+            if block_collection._textures_are_normalized:
+                values = (
+                    values * block_collection.val_range
+                    + block_collection.min_val * path_length
+                )
+            # rays that missed the data integrate to zero, which is correct, so
+            # no masking is applied here.
+            data = ds.arr(values, field_units) * length_unit
+            path_length = path_length * length_unit
+        else:
+            # slice and max_intensity both write a single normalized value
+            if block_collection._textures_are_normalized:
+                values = block_collection._denormalize_by_min_max(values)
+            values[~sampled] = np.nan
+            data = ds.arr(values, field_units)
+
+        camera_state = self._first_pass_camera
+        extent, right, up = image_plane_extent(
+            camera_state["projection_matrix"],
+            camera_state["view_matrix"],
+            camera_state["focus"],
+        )
+
+        return RenderedImagePlane(
+            data=data,
+            extent=extent * length_unit,
+            center=camera_state["focus"] * length_unit,
+            right=right,
+            up=up,
+            path_length=path_length,
+        )

--- a/yt_idv/scene_data/base_data.py
+++ b/yt_idv/scene_data/base_data.py
@@ -28,6 +28,12 @@ class SceneData(traitlets.HasTraits):
         n_data[n_data > 1] = 1.0
         return n_data
 
+    def _denormalize_by_min_max(self, n_data):
+        # inverse of _normalize_by_min_max. Note that values that were clipped
+        # during normalization are not recoverable.
+
+        return n_data * self.val_range + self.min_val
+
     @property
     def val_range(self):
         # the data range (max - min) across all data.

--- a/yt_idv/scene_data/block_collection.py
+++ b/yt_idv/scene_data/block_collection.py
@@ -20,6 +20,8 @@ class BlockCollection(SceneData):
     _yt_geom_str = traitlets.Unicode("cartesian")
     compute_min_max = traitlets.Bool(True)
     always_normalize = traitlets.Bool(False)
+    field = traitlets.Any(default_value=None, allow_none=True)
+    field_units = traitlets.Unicode(default_value=None, allow_none=True)
 
     @traitlets.default("vertex_array")
     def _default_vertex_array(self):
@@ -41,6 +43,7 @@ class BlockCollection(SceneData):
             Should we speed things up by skipping ghost zone generation?
         """
         self.data_source.tiles.set_fields([field], [False], no_ghost=no_ghost)
+        self.field = self.data_source._determine_fields(field)[0]
 
         self._yt_geom_str = str(self.data_source.ds.geometry)
         # note: casting to string for compatibility with new and old geometry
@@ -66,6 +69,8 @@ class BlockCollection(SceneData):
                 block.RightEdge -= left_min
                 block.RightEdge /= scale
         for i, block in enumerate(self.data_source.tiles.traverse()):
+            if self.field_units is None:
+                self.field_units = str(getattr(block.my_data[0], "units", ""))
             min_val = min(min_val, np.nanmin(np.abs(block.my_data[0])).min())
             max_val = max(max_val, np.nanmax(np.abs(block.my_data[0])).max())
             self.blocks[id(block)] = (i, block)
@@ -243,6 +248,37 @@ class BlockCollection(SceneData):
             )
             self.texture_objects[vbo_i] = data_tex
             self.bitmap_objects[vbo_i] = bitmap_tex
+
+    @property
+    def _textures_are_normalized(self) -> bool:
+        # whether or not _load_textures min/max normalized the 3D textures
+        return self.max_val != self.min_val or self.always_normalize
+
+    @property
+    def internal_length_unit(self):
+        """
+        The physical length of a single unit of the internal coordinate system.
+
+        Block edges and spacings are rescaled before being handed to the shaders
+        (to unitary units for cartesian data, to fractions of the maximum radius
+        for spherical data), so any length measured in the rendered scene --
+        camera offsets, ray path lengths -- must be multiplied by this value to
+        get a physical length.
+        """
+        ds = self.data_source.ds
+        if self._yt_geom_str == "cartesian":
+            if self.scale:
+                raise NotImplementedError(
+                    "Physical lengths cannot be recovered when the block "
+                    "collection is initialized with scale=True."
+                )
+            return ds.quan(1.0, "unitary").in_units("code_length")
+        elif self._yt_geom_str == "spherical":
+            rad_index = ds.coordinates.axis_id["r"]
+            return ds.domain_right_edge[rad_index].in_units("code_length")
+        raise NotImplementedError(
+            f"{self.name} does not implement {self._yt_geom_str} geometries."
+        )
 
     _grid_id_list = None
 

--- a/yt_idv/shaders/projection.frag.glsl
+++ b/yt_idv/shaders/projection.frag.glsl
@@ -6,8 +6,15 @@ bool sample_texture(vec3 tex_curr_pos, inout vec4 curr_color, float tdelta,
     vec3 offset_bmap_pos = get_offset_texture_position(bitmap_tex, tex_curr_pos);
     float map_sample = texture(bitmap_tex, offset_bmap_pos).r;
     if (map_sample > 0.0) {
-        float val = length(tdelta * dir) * tex_sample.r + curr_color.r;
-        curr_color = vec4(val, val, val, 1.0);
+        // the g channel accumulates the path length over the same steps that
+        // contribute to the integral in the r channel. Since the texture values
+        // are min/max normalized, the path length is required to recover the
+        // integral of the un-normalized values (see
+        // BlockRendering.rendered_image_plane). Note that only the r channel
+        // is used in the final color output (apply_colormap only uses r)
+        float ds = length(tdelta * dir);
+        float val = ds * tex_sample.r + curr_color.r;
+        curr_color = vec4(val, curr_color.g + ds, val, 1.0);
     }
     return bool(map_sample > 0.0);
 }

--- a/yt_idv/shaders/ray_tracing.frag.glsl
+++ b/yt_idv/shaders/ray_tracing.frag.glsl
@@ -98,6 +98,17 @@ void main()
     t0 = max(t0, 0.0);
     if (t1 <= t0) discard;
 
+    // Each pixel within the silhouette of the block is covered by two faces of
+    // the cube emitted by the geometry shader, and both of them march the same
+    // t0 -> t1 segment. Face culling is supposed to drop one of them, but some
+    // drivers do not apply it reliably, and a duplicated march doubles the
+    // result of the integrating render methods (which blend additively). So
+    // keep only the fragment on the exiting face, which is also the one that
+    // survives culling: the ray leaves the box at t1, and the entering face,
+    // at t0, may be clipped by the near plane or lie behind the camera.
+    float t_face = dot(v_model.xyz - camera_pos.xyz, dir) / dot(dir, dir);
+    if (t_face < 0.5 * (t0 + t1)) discard;
+
     // Some more discussion of this here:
     //  http://prideout.net/blog/?p=64
 

--- a/yt_idv/shaders/ray_tracing.frag.glsl
+++ b/yt_idv/shaders/ray_tracing.frag.glsl
@@ -98,17 +98,6 @@ void main()
     t0 = max(t0, 0.0);
     if (t1 <= t0) discard;
 
-    // Each pixel within the silhouette of the block is covered by two faces of
-    // the cube emitted by the geometry shader, and both of them march the same
-    // t0 -> t1 segment. Face culling is supposed to drop one of them, but some
-    // drivers do not apply it reliably, and a duplicated march doubles the
-    // result of the integrating render methods (which blend additively). So
-    // keep only the fragment on the exiting face, which is also the one that
-    // survives culling: the ray leaves the box at t1, and the entering face,
-    // at t0, may be clipped by the near plane or lie behind the camera.
-    float t_face = dot(v_model.xyz - camera_pos.xyz, dir) / dot(dir, dir);
-    if (t_face < 0.5 * (t0 + t1)) discard;
-
     // Some more discussion of this here:
     //  http://prideout.net/blog/?p=64
 

--- a/yt_idv/tests/test_rendered_image_plane.py
+++ b/yt_idv/tests/test_rendered_image_plane.py
@@ -104,8 +104,10 @@ def test_constant_values_are_denormalized(constant_rc, render_method):
     block_collection = component.data
 
     values = frb.data[np.isfinite(frb.data)]
-    assert values.min() == block_collection.min_val
-    assert values.max() == block_collection.max_val
+    # the values round-trip through float32 normalization on the GPU, which
+    # some drivers do not reproduce bit-exactly: allow a few float32 ulps
+    assert_allclose(values.min().d, block_collection.min_val, rtol=1e-6)
+    assert_allclose(values.max().d, block_collection.max_val, rtol=1e-6)
 
     # pixels that no ray sampled should not masquerade as data
     assert np.isnan(frb.data).any()

--- a/yt_idv/tests/test_rendered_image_plane.py
+++ b/yt_idv/tests/test_rendered_image_plane.py
@@ -1,0 +1,182 @@
+"""Tests for extracting data values from a rendered scene."""
+
+import numpy as np
+import pytest
+import yt
+from numpy.testing import assert_allclose
+from unyt import Unit
+
+import yt_idv
+from yt_idv.rendered_image_plane import image_plane_extent
+
+
+@pytest.fixture()
+def osmesa_uniform():
+    """An OSMesa context with a uniform grid whose density is in [1, 2) g/cm**3.
+
+    The nonzero minimum matters: the 3D textures are min/max normalized, so a
+    field that does not approach zero exercises the full de-normalization.
+    """
+    rng = np.random.default_rng(42)
+    shape = (32, 32, 32)
+    ds = yt.load_uniform_grid(
+        {("gas", "density"): (1.0 + rng.random(shape), "g/cm**3")},
+        shape,
+        length_unit="kpc",
+        bbox=np.array([[0.0, 1.0]] * 3),
+    )
+    rc = yt_idv.render_context("osmesa", width=512, height=512)
+    rc.add_scene(ds.all_data(), ("gas", "density"), no_ghost=False)
+    rc.scene.components[0].store_first_pass_fb = True
+    yield rc
+    rc.osmesa.OSMesaDestroyContext(rc.context)
+
+
+def test_block_collection_field_metadata(osmesa_uniform):
+    block_collection = osmesa_uniform.scene.components[0].data
+    assert block_collection.field == ("gas", "density")
+    assert block_collection.field_units == "g/cm**3"
+    assert block_collection._textures_are_normalized
+    assert block_collection.internal_length_unit == 1.0  # code_length
+    assert str(block_collection.internal_length_unit.units) == "code_length"
+
+
+def test_requires_stored_framebuffer(osmesa_uniform):
+    component = osmesa_uniform.scene.components[0]
+    component.store_first_pass_fb = False
+    with pytest.raises(RuntimeError, match="store_first_pass_fb"):
+        component.rendered_image_plane()
+
+
+def test_unsupported_render_method(osmesa_uniform):
+    component = osmesa_uniform.scene.components[0]
+    component.render_method = "transfer_function"
+    osmesa_uniform.scene.render()
+    with pytest.raises(NotImplementedError, match="transfer_function"):
+        component.rendered_image_plane()
+
+
+@pytest.mark.parametrize("render_method", ["max_intensity", "slice"])
+def test_values_are_denormalized(osmesa_uniform, render_method):
+    component = osmesa_uniform.scene.components[0]
+    component.render_method = render_method
+    osmesa_uniform.scene.render()
+
+    frb = component.rendered_image_plane()
+    block_collection = component.data
+    assert str(frb.data.units) == "g/cm**3"
+
+    values = frb.data[np.isfinite(frb.data)]
+    # the raw framebuffer is normalized to (0, 1); the returned values must
+    # instead span the range of the data that built the textures
+    assert values.min() >= block_collection.min_val
+    assert values.max() <= block_collection.max_val
+    assert values.max() > 1.0
+    # pixels that no ray sampled should not masquerade as data
+    assert np.isnan(frb.data).any()
+
+
+def test_projection_path_length_and_units(osmesa_uniform):
+    component = osmesa_uniform.scene.components[0]
+    component.render_method = "projection"
+
+    # look down an axis with a narrow field of view, so that rays are close to
+    # parallel and pass through the full depth of the domain exactly once
+    camera = osmesa_uniform.scene.camera
+    camera.update(position=[0.5, 0.5, 20.0], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
+    camera.fov = 3.0
+    camera.far_plane = 100.0
+    camera._update_matrices()
+    osmesa_uniform.scene.render()
+
+    frb = component.rendered_image_plane()
+    # field units times a length, which unyt simplifies to a surface density
+    assert frb.data.units.dimensions == Unit("g/cm**2").dimensions
+    assert str(frb.path_length.units) == "code_length"
+
+    ny, nx = frb.data.shape
+    center = (ny // 2, nx // 2)
+    # the domain is one code_length deep; the ray marcher can overshoot the exit
+    # point by up to one step (dx = 1/32)
+    assert_allclose(frb.path_length[center].d, 1.0, atol=1.5 / 32)
+
+    # the path-averaged value has to land in the range of the data, which it
+    # only does if the min/max normalization has been undone using the path
+    # length: without that correction it would fall below min_val
+    mean_along_ray = (frb.data / frb.path_length).to("g/cm**3")
+    sampled = frb.path_length.d > 0.5
+    assert mean_along_ray[sampled].min() >= component.data.min_val
+    assert mean_along_ray[sampled].max() <= component.data.max_val
+    assert_allclose(mean_along_ray[center].d, 1.5, atol=0.1)
+
+
+def test_frb_geometry(osmesa_uniform):
+    component = osmesa_uniform.scene.components[0]
+    component.render_method = "slice"
+
+    camera = osmesa_uniform.scene.camera
+    camera.update(position=[0.5, 0.5, 2.5], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
+    camera.fov = 45.0
+    camera.aspect_ratio = 1.0
+    camera._update_matrices()
+    osmesa_uniform.scene.render()
+
+    frb = component.rendered_image_plane()
+
+    # for a symmetric frustum the visible extent at the focus plane is
+    # 2 * distance * tan(fov / 2)
+    distance = 2.0
+    expected = 2 * distance * np.tan(np.radians(45.0) / 2)
+    assert_allclose(frb.width.d, expected, rtol=1e-5)
+    assert_allclose(frb.height.d, expected, rtol=1e-5)
+    assert str(frb.width.units) == "code_length"
+    assert_allclose(frb.center.d, [0.5, 0.5, 0.5], atol=1e-6)
+    assert_allclose(frb.extent.d, [-expected / 2, expected / 2] * 2, rtol=1e-5)
+
+    assert frb.data.shape == component.fb.viewport[3:1:-1]
+
+
+def test_integrate(osmesa_uniform):
+    component = osmesa_uniform.scene.components[0]
+    component.render_method = "slice"
+    osmesa_uniform.scene.render()
+
+    frb = component.rendered_image_plane()
+    ny, nx = frb.data.shape
+    dx, dy = frb.pixel_size
+    assert_allclose((dx * nx).d, frb.width.d, rtol=1e-12)
+    assert_allclose((dy * ny).d, frb.height.d, rtol=1e-12)
+
+    integral = frb.integrate()
+    assert integral.units.dimensions == Unit("g/cm").dimensions
+
+    # NaN pixels are skipped, so the integral is the mean of the sampled data
+    # times the area those pixels cover
+    sampled = np.isfinite(frb.data)
+    area = sampled.sum() * dx * dy
+    assert_allclose(
+        integral.d, (frb.data[sampled].mean() * area).to(integral.units).d, rtol=1e-6
+    )
+    assert integral.d > 0
+
+
+def test_image_plane_extent_round_trip():
+    from yt.utilities.math_utils import get_lookat_matrix, get_perspective_matrix
+
+    focus = np.array([0.5, 0.5, 0.5])
+    position = np.array([1.0, 2.0, 3.0])
+    view_matrix = get_lookat_matrix(position, focus, np.array([0.0, 1.0, 0.0]))
+
+    for aspect in (1.0, 1.6):
+        projection_matrix = get_perspective_matrix(45.0, aspect, 0.001, 20.0)
+        extent, right, up = image_plane_extent(projection_matrix, view_matrix, focus)
+
+        # the corners of the extent must map back to the corners of the
+        # normalized device cube
+        pmv = projection_matrix @ view_matrix
+        for x, y, expected in (
+            (extent[0], extent[2], [-1.0, -1.0]),
+            (extent[1], extent[3], [1.0, 1.0]),
+        ):
+            clip = pmv @ np.append(focus + x * right + y * up, 1.0)
+            assert_allclose(clip[:2] / clip[3], expected, atol=1e-5)

--- a/yt_idv/tests/test_rendered_image_plane.py
+++ b/yt_idv/tests/test_rendered_image_plane.py
@@ -35,7 +35,8 @@ def constant_rc(make_rc):
     """A rendering context with a 1 m cube at a constant density of 1 g/m**3.
 
     The total mass is 1 g, so a projection of the cube has to integrate to 1 g
-    once the rays are close enough to parallel to be a true projection.
+    once the rays are close enough to parallel to be a true projection. Data
+    is split into 8 grids to check sensitivity to number of grids.
     """
     shape = (32, 32, 32)
     ds = yt.load_uniform_grid(
@@ -43,6 +44,7 @@ def constant_rc(make_rc):
         shape,
         length_unit="m",
         bbox=np.array([[0.0, 1.0]] * 3),
+        nprocs=8,
     )
     rc = make_rc()
     rc.add_scene(ds.all_data(), ("gas", "density"), no_ghost=False)
@@ -232,7 +234,7 @@ def test_integrate_constant(constant_rc):
     # resolution-dependent errors: pixel centers inside the cube's silhouette
     # each count a full pixel of area (up to a half-pixel band around the
     # perimeter of the unit cross-section), and each ray overshoots the exit
-    # face by up to one step
+    # face by up to one step (fixture ds has a single grid, size (32,32,32))
     rtol = 2 * max(dx.d, dy.d) + 1.0 / (32 * component.sample_factor)
     assert_allclose(integral.to("g").d, 1.0, rtol=rtol)
 
@@ -248,9 +250,13 @@ def test_projection_marches_each_ray_once(constant_rc):
     frb = component.rendered_image_plane()
 
     # the default camera looks down the body diagonal of the domain, so no ray
-    # can travel further through it than sqrt(3) code_length (plus the single
-    # step the marcher can overshoot the exit point by)
-    assert frb.path_length.max().d <= np.sqrt(3) + 1.0 / 32
+    # travels further through the data than sqrt(3) code_length. each block's
+    # marcher can overshoot that block's exit by up to one step, a step along a
+    # diagonal ray is sqrt(3) * dx, and a ray can cross at most 2 + 2 + 2 - 2 = 4
+    # blocks of the 2x2x2 decomposition. a double-marched ray would instead
+    # approach 2 * sqrt(3)
+    step = np.sqrt(3) / 32 / component.sample_factor
+    assert frb.path_length.max().d <= np.sqrt(3) + 4 * step
 
 
 def test_image_plane_extent_round_trip():

--- a/yt_idv/tests/test_rendered_image_plane.py
+++ b/yt_idv/tests/test_rendered_image_plane.py
@@ -6,13 +6,12 @@ import yt
 from numpy.testing import assert_allclose
 from unyt import Unit, unyt_array
 
-import yt_idv
 from yt_idv.rendered_image_plane import image_plane_extent
 
 
 @pytest.fixture()
-def osmesa_uniform():
-    """An OSMesa context with a uniform grid whose density is in [1, 2) g/cm**3.
+def uniform_rc(make_rc):
+    """A rendering context with a uniform grid whose density is in [1, 2) g/cm**3.
 
     The nonzero minimum matters: the 3D textures are min/max normalized, so a
     field that does not approach zero exercises the full de-normalization.
@@ -25,16 +24,15 @@ def osmesa_uniform():
         length_unit="kpc",
         bbox=np.array([[0.0, 1.0]] * 3),
     )
-    rc = yt_idv.render_context("osmesa", width=512, height=512)
+    rc = make_rc()
     rc.add_scene(ds.all_data(), ("gas", "density"), no_ghost=False)
     rc.scene.components[0].store_first_pass_fb = True
-    yield rc
-    rc.osmesa.OSMesaDestroyContext(rc.context)
+    return rc
 
 
 @pytest.fixture()
-def osmesa_constant():
-    """An OSMesa context with a 1 m cube at a constant density of 1 g/m**3.
+def constant_rc(make_rc):
+    """A rendering context with a 1 m cube at a constant density of 1 g/m**3.
 
     The total mass is 1 g, so a projection of the cube has to integrate to 1 g
     once the rays are close enough to parallel to be a true projection.
@@ -46,15 +44,14 @@ def osmesa_constant():
         length_unit="m",
         bbox=np.array([[0.0, 1.0]] * 3),
     )
-    rc = yt_idv.render_context("osmesa", width=512, height=512)
+    rc = make_rc()
     rc.add_scene(ds.all_data(), ("gas", "density"), no_ghost=False)
     rc.scene.components[0].store_first_pass_fb = True
-    yield rc
-    rc.osmesa.OSMesaDestroyContext(rc.context)
+    return rc
 
 
-def test_block_collection_field_metadata(osmesa_uniform):
-    block_collection = osmesa_uniform.scene.components[0].data
+def test_block_collection_field_metadata(uniform_rc):
+    block_collection = uniform_rc.scene.components[0].data
     assert block_collection.field == ("gas", "density")
     assert block_collection.field_units == "g/cm**3"
     assert block_collection._textures_are_normalized
@@ -62,26 +59,26 @@ def test_block_collection_field_metadata(osmesa_uniform):
     assert str(block_collection.internal_length_unit.units) == "code_length"
 
 
-def test_requires_stored_framebuffer(osmesa_uniform):
-    component = osmesa_uniform.scene.components[0]
+def test_requires_stored_framebuffer(uniform_rc):
+    component = uniform_rc.scene.components[0]
     component.store_first_pass_fb = False
     with pytest.raises(RuntimeError, match="store_first_pass_fb"):
         component.rendered_image_plane()
 
 
-def test_unsupported_render_method(osmesa_uniform):
-    component = osmesa_uniform.scene.components[0]
+def test_unsupported_render_method(uniform_rc):
+    component = uniform_rc.scene.components[0]
     component.render_method = "transfer_function"
-    osmesa_uniform.scene.render()
+    uniform_rc.scene.render()
     with pytest.raises(NotImplementedError, match="transfer_function"):
         component.rendered_image_plane()
 
 
 @pytest.mark.parametrize("render_method", ["max_intensity", "slice"])
-def test_values_are_denormalized(osmesa_uniform, render_method):
-    component = osmesa_uniform.scene.components[0]
+def test_values_are_denormalized(uniform_rc, render_method):
+    component = uniform_rc.scene.components[0]
     component.render_method = render_method
-    osmesa_uniform.scene.render()
+    uniform_rc.scene.render()
 
     frb = component.rendered_image_plane()
     block_collection = component.data
@@ -98,10 +95,10 @@ def test_values_are_denormalized(osmesa_uniform, render_method):
 
 
 @pytest.mark.parametrize("render_method", ["max_intensity", "slice"])
-def test_constant_values_are_denormalized(osmesa_constant, render_method):
-    component = osmesa_constant.scene.components[0]
+def test_constant_values_are_denormalized(constant_rc, render_method):
+    component = constant_rc.scene.components[0]
     component.render_method = render_method
-    osmesa_constant.scene.render()
+    constant_rc.scene.render()
 
     frb = component.rendered_image_plane()
     block_collection = component.data
@@ -114,18 +111,18 @@ def test_constant_values_are_denormalized(osmesa_constant, render_method):
     assert np.isnan(frb.data).any()
 
 
-def test_projection_path_length_and_units(osmesa_uniform):
-    component = osmesa_uniform.scene.components[0]
+def test_projection_path_length_and_units(uniform_rc):
+    component = uniform_rc.scene.components[0]
     component.render_method = "projection"
 
     # look down an axis with a narrow field of view, so that rays are close to
     # parallel and pass through the full depth of the domain exactly once
-    camera = osmesa_uniform.scene.camera
+    camera = uniform_rc.scene.camera
     camera.update(position=[0.5, 0.5, 20.0], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
     camera.fov = 3.0
     camera.far_plane = 100.0
     camera._update_matrices()
-    osmesa_uniform.scene.render()
+    uniform_rc.scene.render()
 
     frb = component.rendered_image_plane()
     # field units times a length, which unyt simplifies to a surface density
@@ -148,16 +145,16 @@ def test_projection_path_length_and_units(osmesa_uniform):
     assert_allclose(mean_along_ray[center].d, 1.5, atol=0.1)
 
 
-def test_frb_geometry(osmesa_uniform):
-    component = osmesa_uniform.scene.components[0]
+def test_frb_geometry(uniform_rc):
+    component = uniform_rc.scene.components[0]
     component.render_method = "slice"
 
-    camera = osmesa_uniform.scene.camera
+    camera = uniform_rc.scene.camera
     camera.update(position=[0.5, 0.5, 2.5], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
     camera.fov = 45.0
     camera.aspect_ratio = 1.0
     camera._update_matrices()
-    osmesa_uniform.scene.render()
+    uniform_rc.scene.render()
 
     frb = component.rendered_image_plane()
 
@@ -174,10 +171,10 @@ def test_frb_geometry(osmesa_uniform):
     assert frb.data.shape == component.fb.viewport[3:1:-1]
 
 
-def test_integrate(osmesa_uniform):
-    component = osmesa_uniform.scene.components[0]
+def test_integrate(uniform_rc):
+    component = uniform_rc.scene.components[0]
     component.render_method = "slice"
-    osmesa_uniform.scene.render()
+    uniform_rc.scene.render()
 
     frb = component.rendered_image_plane()
     ny, nx = frb.data.shape
@@ -198,15 +195,15 @@ def test_integrate(osmesa_uniform):
     assert integral.d > 0
 
 
-def test_integrate_constant(osmesa_constant):
-    component = osmesa_constant.scene.components[0]
+def test_integrate_constant(constant_rc):
+    component = constant_rc.scene.components[0]
     component.render_method = "projection"
 
     # the camera is a perspective one, so it only integrates to the total mass
     # in the limit of parallel rays: view the cube from far away with a field of
     # view narrow enough that it still fills a good fraction of the image. the
     # rays then diverge by at most fov / 2 = 1 degree.
-    camera = osmesa_constant.scene.camera
+    camera = constant_rc.scene.camera
     camera.update(position=[0.5, 0.5, 60.0], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
     camera.fov = 2.0
     camera.aspect_ratio = 1.0
@@ -215,7 +212,7 @@ def test_integrate_constant(osmesa_constant):
     # the ray marcher overshoots the exit point by up to one step, which is a
     # 1 / (2 * 32 * sample_factor) error on a path of one code_length
     component.sample_factor = 8.0
-    osmesa_constant.scene.render()
+    constant_rc.scene.render()
 
     frb = component.rendered_image_plane()
     ny, nx = frb.data.shape
@@ -233,13 +230,13 @@ def test_integrate_constant(osmesa_constant):
     assert_allclose(integral.to("g").d, 1.0, rtol=1e-2)
 
 
-def test_projection_marches_each_ray_once(osmesa_constant):
+def test_projection_marches_each_ray_once(constant_rc):
     # every pixel within the silhouette of a block is covered by two faces of
     # the cube the geometry shader emits, and the projection shader blends
     # additively, so a ray that is marched twice doubles the integral
-    component = osmesa_constant.scene.components[0]
+    component = constant_rc.scene.components[0]
     component.render_method = "projection"
-    osmesa_constant.scene.render()
+    constant_rc.scene.render()
 
     frb = component.rendered_image_plane()
 

--- a/yt_idv/tests/test_rendered_image_plane.py
+++ b/yt_idv/tests/test_rendered_image_plane.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import yt
 from numpy.testing import assert_allclose
-from unyt import Unit
+from unyt import Unit, unyt_array
 
 import yt_idv
 from yt_idv.rendered_image_plane import image_plane_extent
@@ -23,6 +23,27 @@ def osmesa_uniform():
         {("gas", "density"): (1.0 + rng.random(shape), "g/cm**3")},
         shape,
         length_unit="kpc",
+        bbox=np.array([[0.0, 1.0]] * 3),
+    )
+    rc = yt_idv.render_context("osmesa", width=512, height=512)
+    rc.add_scene(ds.all_data(), ("gas", "density"), no_ghost=False)
+    rc.scene.components[0].store_first_pass_fb = True
+    yield rc
+    rc.osmesa.OSMesaDestroyContext(rc.context)
+
+
+@pytest.fixture()
+def osmesa_constant():
+    """An OSMesa context with a 1 m cube at a constant density of 1 g/m**3.
+
+    The total mass is 1 g, so a projection of the cube has to integrate to 1 g
+    once the rays are close enough to parallel to be a true projection.
+    """
+    shape = (32, 32, 32)
+    ds = yt.load_uniform_grid(
+        {("gas", "density"): unyt_array(np.ones(shape), "g/m**3")},
+        shape,
+        length_unit="m",
         bbox=np.array([[0.0, 1.0]] * 3),
     )
     rc = yt_idv.render_context("osmesa", width=512, height=512)
@@ -72,6 +93,23 @@ def test_values_are_denormalized(osmesa_uniform, render_method):
     assert values.min() >= block_collection.min_val
     assert values.max() <= block_collection.max_val
     assert values.max() > 1.0
+    # pixels that no ray sampled should not masquerade as data
+    assert np.isnan(frb.data).any()
+
+
+@pytest.mark.parametrize("render_method", ["max_intensity", "slice"])
+def test_constant_values_are_denormalized(osmesa_constant, render_method):
+    component = osmesa_constant.scene.components[0]
+    component.render_method = render_method
+    osmesa_constant.scene.render()
+
+    frb = component.rendered_image_plane()
+    block_collection = component.data
+
+    values = frb.data[np.isfinite(frb.data)]
+    assert values.min() == block_collection.min_val
+    assert values.max() == block_collection.max_val
+
     # pixels that no ray sampled should not masquerade as data
     assert np.isnan(frb.data).any()
 
@@ -158,6 +196,57 @@ def test_integrate(osmesa_uniform):
         integral.d, (frb.data[sampled].mean() * area).to(integral.units).d, rtol=1e-6
     )
     assert integral.d > 0
+
+
+def test_integrate_constant(osmesa_constant):
+    component = osmesa_constant.scene.components[0]
+    component.render_method = "projection"
+
+    # the camera is a perspective one, so it only integrates to the total mass
+    # in the limit of parallel rays: view the cube from far away with a field of
+    # view narrow enough that it still fills a good fraction of the image. the
+    # rays then diverge by at most fov / 2 = 1 degree.
+    camera = osmesa_constant.scene.camera
+    camera.update(position=[0.5, 0.5, 60.0], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
+    camera.fov = 2.0
+    camera.aspect_ratio = 1.0
+    camera.far_plane = 100.0
+    camera._update_matrices()
+    # the ray marcher overshoots the exit point by up to one step, which is a
+    # 1 / (2 * 32 * sample_factor) error on a path of one code_length
+    component.sample_factor = 8.0
+    osmesa_constant.scene.render()
+
+    frb = component.rendered_image_plane()
+    ny, nx = frb.data.shape
+    dx, dy = frb.pixel_size
+    assert_allclose((dx * nx).d, frb.width.d, rtol=1e-12)
+    assert_allclose((dy * ny).d, frb.height.d, rtol=1e-12)
+
+    # the whole cube has to be inside the image, or the integral would clip it
+    assert frb.width.d > 1.0 and frb.height.d > 1.0
+
+    integral = frb.integrate()
+    assert integral.units.dimensions == Unit("g").dimensions
+
+    # a 1 m cube at a constant 1 g/m**3 holds 1 g
+    assert_allclose(integral.to("g").d, 1.0, rtol=1e-2)
+
+
+def test_projection_marches_each_ray_once(osmesa_constant):
+    # every pixel within the silhouette of a block is covered by two faces of
+    # the cube the geometry shader emits, and the projection shader blends
+    # additively, so a ray that is marched twice doubles the integral
+    component = osmesa_constant.scene.components[0]
+    component.render_method = "projection"
+    osmesa_constant.scene.render()
+
+    frb = component.rendered_image_plane()
+
+    # the default camera looks down the body diagonal of the domain, so no ray
+    # can travel further through it than sqrt(3) code_length (plus the single
+    # step the marcher can overshoot the exit point by)
+    assert frb.path_length.max().d <= np.sqrt(3) + 1.0 / 32
 
 
 def test_image_plane_extent_round_trip():

--- a/yt_idv/tests/test_rendered_image_plane.py
+++ b/yt_idv/tests/test_rendered_image_plane.py
@@ -228,8 +228,13 @@ def test_integrate_constant(constant_rc):
     integral = frb.integrate()
     assert integral.units.dimensions == Unit("g").dimensions
 
-    # a 1 m cube at a constant 1 g/m**3 holds 1 g
-    assert_allclose(integral.to("g").d, 1.0, rtol=1e-2)
+    # a 1 m cube at a constant 1 g/m**3 holds 1 g. the integral carries two
+    # resolution-dependent errors: pixel centers inside the cube's silhouette
+    # each count a full pixel of area (up to a half-pixel band around the
+    # perimeter of the unit cross-section), and each ray overshoots the exit
+    # face by up to one step
+    rtol = 2 * max(dx.d, dy.d) + 1.0 / (32 * component.sample_factor)
+    assert_allclose(integral.to("g").d, 1.0, rtol=rtol)
 
 
 def test_projection_marches_each_ray_once(constant_rc):


### PR DESCRIPTION
@matthewturk , I was working on ways to verify the spherical volume rendering (e.g., check that max values are resolved, check that integrating a sphere yields the volume of the sphere) and found myself wanting to pull out the first-pass frame buffer from the rendering pipeline. So I wrote up a skeleton and had Claude fill in the blanks to give us a new `RenderedImagePlane` as a way to get an array with correct units for the data in the frame buffer. Not thoroughly tested yet, but I think this could be useful in a number of ways beyond my spherical volume rendering benchmarking: (1) writing tests for yt_idv , (2) using the yt_idv rendering from yt (or elsewhere) and getting back values that are units aware. 

## Claude summary from here on

Adds `BlockRendering.rendered_image_plane()`, which turns the first rendering pass of a block scene back into physical data values and reports the physical size of the view. Previously the only way to get at the first pass was the raw framebuffer, whose values are min/max normalized and measured in the renderer's internal coordinate system.

```python
rc = yt_idv.render_context(height=800, width=800)
rc.add_scene(ds, "density", no_ghost=True)
component = rc.scene.components[0]
component.store_first_pass_fb = True
rc.scene.render()

plane = component.rendered_image_plane()
plane.data          # (ny, nx) unyt array, e.g. g/cm**3 for a slice
plane.extent        # (xmin, xmax, ymin, ymax) about the camera focus
plane.width         # physical width of the view
plane.integrate()   # integral over the plane
```

## What the first pass actually contains

Three things had to be undone to recover true data values.

**Normalization.** `BlockCollection._load_textures` stores `n = clip((|d| - min_val) / (max_val - min_val), 0, 1)` in the 3D textures. No log is applied — that happens in the second pass, in `apply_colormap.frag.glsl` — so inverting is linear. `min_val`/`max_val` are taken over the *vertex-centered* block data, so returned values can fall slightly outside the range of the cell-centered field, particularly with `no_ghost=True`. Values are also absolute values of the field, since the textures are built from `np.abs`.

**Projection needed a path length.** The projection shader accumulates `I = Σ nᵢ dsᵢ`, and recovering `Σ|dᵢ| dsᵢ = I·(max−min) + min·L` requires the total path length `L`, which was being discarded. `projection.frag.glsl` now accumulates `L` in the otherwise-unused G channel of the framebuffer; blending is additive, so it sums across blocks exactly the way the integral does. `L` is exposed as `RenderedImagePlane.path_length`.

**Length units.** Block edges are rescaled before reaching the shaders — to `unitary` for cartesian data, to fractions of the maximum radius for spherical — so lengths measured in the scene are not physical. `BlockCollection.internal_length_unit` exposes the conversion. Projections therefore come back in field units times a length (unyt simplifies e.g. `g/cm**3 × cm` to `g/cm**2`); slices and maximum intensity come back in raw field units, read from the block data via the new `BlockCollection.field_units`.

## Physical extent of the view

The camera uses a perspective projection, so the region of space the image covers depends on distance. `image_plane_extent` un-projects the corners of the normalized device cube through `inv(projection @ view)` at the depth of the camera focus. Working from the matrices rather than from `fov` and `aspect_ratio` directly means the asymmetric frustum that `yt.utilities.math_utils.get_perspective_matrix` produces when `aspect_ratio != 1` is handled correctly. The camera matrices are snapshotted at render time, so a later camera move does not corrupt a stored buffer.

## ~~Two~~ One pre-existing bug~~s~~ found along the way

Neither is fixed here; both are worked around or documented.

~~**Projection double-counts for non-axis-aligned views.** The cube triangle strip in `grid_expand.geom.glsl` has inconsistent winding, so two front faces survive back-face culling and each runs a full ray traversal. Confirmed directly: for a corner-on view the framebuffer alpha (which counts contributing fragments) is exactly 2.0 and the path length is 3.46 = 2·√3; axis-aligned gives 1.0. This inflates the existing rendered projection too, not just the new buffer. `data` and `path_length` are affected identically, so `data / path_length` is immune. Fixing it means changing the winding, which changes projection output for everyone — left for a separate PR.~~ This was hallucinated -- I tested this separately, not a bug.

**`Framebuffer.data` is mis-shaped for non-square viewports.** `glReadPixels` allocates its result as `(width, height, 4)` but OpenGL fills it row-major in y, so the array has to be reshaped to be indexed as `[y, x, channel]`. Handled in the new `_read_first_pass_fb`; `SceneGraph.image` still has the issue, alongside a discarded `arr.swapaxes(0, 1)`. Relatedly, `osmesa_context.py:41` passes `height, width` to `OSMesaMakeCurrent`, which takes `width, height`. (this one seems real)


