### PR TITLE
fix pixels dropped at block boundaries in slice rendering

### DIFF
--- a/yt_idv/cameras/base_camera.py
+++ b/yt_idv/cameras/base_camera.py
@@ -114,6 +114,9 @@ class BaseCamera(traitlets.HasTraits):
         shader_program._set_uniform(
             "viewport", np.array(GL.glGetIntegerv(GL.GL_VIEWPORT), dtype="f4")
         )
+        shader_program._set_uniform(
+            "inv_pmvm", np.linalg.inv(self.projection_matrix @ self.view_matrix)
+        )
         shader_program._set_uniform("near_plane", self.near_plane)
         shader_program._set_uniform("far_plane", self.far_plane)
         shader_program._set_uniform("camera_pos", self.position)

--- a/yt_idv/shaders/default.vert.glsl
+++ b/yt_idv/shaders/default.vert.glsl
@@ -18,7 +18,7 @@ void main()
     inverse_proj = inverse(projection);
     // inverse model-view-matrix
     inverse_mvm = inverse(modelview);
-    inverse_pmvm = inverse(projection * modelview);
+    inverse_pmvm = inv_pmvm;
     gl_Position = projection * modelview * model_vertex;
     dx = vec3(in_dx);
     left_edge = vec3(in_left_edge);

--- a/yt_idv/shaders/grid_position.vert.glsl
+++ b/yt_idv/shaders/grid_position.vert.glsl
@@ -36,7 +36,7 @@ void main()
 
     // inverse model-view-matrix
     vinverse_mvm = inverse(modelview);
-    vinverse_pmvm = inverse(projection * modelview);
+    vinverse_pmvm = inv_pmvm;
     gl_Position = projection * modelview * model_vertex;
 
     // native coordinates

--- a/yt_idv/shaders/header.inc.glsl
+++ b/yt_idv/shaders/header.inc.glsl
@@ -2,3 +2,19 @@
 
 const float INFINITY = 1. / 0.;
 const float PI = 3.1415926535897932384626433832795;
+
+// Fraction of the coordinate scale by which bounding box tests are padded.
+// A ray position that lands on a face shared by two blocks is reconstructed
+// slightly differently by each of them in float32, so an exact test can place
+// the point outside both blocks and leave the pixel undrawn.
+const float BBOX_TOL = 1e-5;
+
+bool within_bb(vec3 pos, vec3 left_edge, vec3 right_edge)
+{
+    // the float32 error in pos comes from arithmetic on the coordinates
+    // themselves, so it scales with their magnitude and not with the cell size
+    vec3 tol = BBOX_TOL * max(abs(left_edge), abs(right_edge));
+    bvec3 left =  greaterThanEqual(pos, left_edge - tol);
+    bvec3 right = lessThanEqual(pos, right_edge + tol);
+    return all(left) && all(right);
+}

--- a/yt_idv/shaders/isocontour.frag.glsl
+++ b/yt_idv/shaders/isocontour.frag.glsl
@@ -8,13 +8,6 @@ flat in mat4 inverse_pmvm;
 flat in ivec3 texture_offset;
 out vec4 output_color;
 
-bool within_bb(vec3 pos)
-{
-    bvec3 left =  greaterThanEqual(pos, left_edge);
-    bvec3 right = lessThanEqual(pos, right_edge);
-    return all(left) && all(right);
-}
-
 vec3 get_offset_texture_position(sampler3D tex, vec3 tex_curr_pos)
 {
     ivec3 texsize = textureSize(tex, 0); // lod (mipmap level) always 0?

--- a/yt_idv/shaders/octree_position.vert.glsl
+++ b/yt_idv/shaders/octree_position.vert.glsl
@@ -18,7 +18,7 @@ void main()
     inverse_proj = inverse(projection);
     // inverse model-view-matrix
     inverse_mvm = inverse(modelview);
-    inverse_pmvm = inverse(projection * modelview);
+    inverse_pmvm = inv_pmvm;
     gl_Position = projection * modelview * v_model;
     dx = vec3(in_dx);
     left_edge = vec3(in_left_edge);

--- a/yt_idv/shaders/ray_tracing.frag.glsl
+++ b/yt_idv/shaders/ray_tracing.frag.glsl
@@ -15,13 +15,6 @@ flat in vec3 dx_cart;
 
 out vec4 output_color;
 
-bool within_bb(vec3 pos)
-{
-    bvec3 left =  greaterThanEqual(pos, left_edge);
-    bvec3 right = lessThanEqual(pos, right_edge);
-    return all(left) && all(right);
-}
-
 #ifdef SPHERICAL_GEOM
 vec3 cart_to_sphere_vec3(vec3 v) {
     // transform a single point in cartesian coords to spherical
@@ -139,7 +132,7 @@ void main()
         // texture position
         #ifdef SPHERICAL_GEOM
         ray_position_native = cart_to_sphere_vec3(ray_position);
-        within_el = within_bb(ray_position_native);
+        within_el = within_bb(ray_position_native, left_edge, right_edge);
         #else
         ray_position_native = ray_position;
         #endif

--- a/yt_idv/shaders/slice_sample.frag.glsl
+++ b/yt_idv/shaders/slice_sample.frag.glsl
@@ -7,13 +7,6 @@ flat in mat4 inverse_mvm;
 flat in mat4 inverse_pmvm;
 out vec4 output_color;
 
-bool within_bb(vec3 pos)
-{
-    bvec3 left =  greaterThanEqual(pos, left_edge);
-    bvec3 right = lessThanEqual(pos, right_edge);
-    return all(left) && all(right);
-}
-
 bool sample_texture(vec3 tex_curr_pos, inout vec4 curr_color, float tdelta,
                     float t, vec3 dir);
 vec4 cleanup_phase(in vec4 curr_color, in vec3 dir, in float t0, in float t1);
@@ -25,31 +18,25 @@ vec4 cleanup_phase(in vec4 curr_color, in vec3 dir, in float t0, in float t1);
 
 void main()
 {
-    // Obtain screen coordinates
-    // https://www.opengl.org/wiki/Compute_eye_space_from_window_space#From_gl_FragCoord
-    vec4 ndcPos;
-    ndcPos.xy = ((2.0 * gl_FragCoord.xy) - (2.0 * viewport.xy)) / (viewport.zw) - 1;
-    ndcPos.z = (2.0 * gl_FragCoord.z - 1.0);
-    ndcPos.w = 1.0;
+    // the interpolated position on this block's face that the ray passes
+    // through. un-projecting gl_FragCoord through inverse_pmvm gives the same
+    // point in exact arithmetic, but with a small near plane that matrix is
+    // badly conditioned and the float32 result is off by enough that two
+    // blocks disagree about where a ray crosses the face they share.
+    vec3 ray_position = v_model.xyz;
 
-    vec4 clipPos = ndcPos / gl_FragCoord.w;
-    vec4 eyePos = inverse_proj * clipPos;
-    eyePos /= eyePos.w;
-
-    vec3 ray_position = (inverse_pmvm * clipPos).xyz;
-
-    // Five samples
     vec3 dir = normalize(camera_pos.xyz - ray_position);
-    dir = max(abs(dir), 0.0001) * sign(dir);
     vec4 curr_color = vec4(0.0);
 
     // We'll compute the t at which this ray intersects the slice. If that t
     // results in a position that is within this box, we'll sample and return.
     // For a nice, rust-y walkthrough: https://samsymons.com/blog/math-notes-ray-plane-intersection/
     float t_intersect = dot((slice_position - ray_position), slice_normal) / dot(dir, slice_normal);
-    if (abs(t_intersect) < 1e-5) discard;
+    // the ray runs parallel to the slice (or through it at a grazing angle
+    // that overflows), so it never lands in this block
+    if (isinf(t_intersect) || isnan(t_intersect)) discard;
     ray_position += t_intersect * dir;
-    if (!within_bb(ray_position)) discard;
+    if (!within_bb(ray_position, left_edge, right_edge)) discard;
 
     vec3 range = (right_edge + dx/2.0) - (left_edge - dx/2.0);
     vec3 nzones = range / dx;

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -79,6 +79,33 @@ def test_slice(osmesa_fake_amr, image_store):
     image_store(osmesa_fake_amr)
 
 
+def _interior_gaps(image):
+    """Undrawn pixels that are enclosed by drawn pixels along both axes."""
+    drawn = image[:, :, 3] > 0
+
+    def enclosed(axis):
+        forward = np.maximum.accumulate(drawn, axis=axis)
+        backward = np.flip(np.maximum.accumulate(np.flip(drawn, axis), axis), axis)
+        return forward & backward
+
+    return ~drawn & enclosed(0) & enclosed(1)
+
+
+@pytest.mark.parametrize("near_plane", [1e-4, 1e-2])
+def test_slice_no_block_boundary_gaps(osmesa_fake_amr, near_plane):
+    """Rays that hit a face shared by two blocks must be drawn by one of them."""
+    component = osmesa_fake_amr.scene.components[0]
+    component.render_method = "slice"
+    component.slice_position = (0.5, 0.5, 0.5)
+    component.slice_normal = (1.0, 1.0, 0.0)
+
+    camera = osmesa_fake_amr.scene.camera
+    camera.near_plane = near_plane
+    camera._update_matrices()
+
+    assert _interior_gaps(osmesa_fake_amr.run()).sum() == 0
+
+
 def test_annotate_boxes(osmesa_empty, image_store):
     """Check the box annotation."""
     osmesa_empty.scene.add_box([0.0, 0.0, 0.0], [1.0, 1.0, 1.0])


### PR DESCRIPTION
use ray position from v_model in slice_sample, shared bbox test in header.inc.glsl (with precision padding), pass down inv_pmvm as a uniform to avoid float32 precision loss.

closes #252