### PR TITLE
Skip whitespace control chars when building text glyph textures

### DIFF
--- a/yt_idv/scene_annotations/text.py
+++ b/yt_idv/scene_annotations/text.py
@@ -29,6 +29,8 @@ class TextAnnotation(SceneAnnotation):
             x = 0
             dy = 0
             for c in line:
+                if c not in self.data.characters:
+                    continue
                 e = self.data.characters[c]
                 draw_instructions.append((x, y, e.texture, e.vbo_offset))
                 dy = max(dy, e.vert_advance)

--- a/yt_idv/scene_data/text_characters.py
+++ b/yt_idv/scene_data/text_characters.py
@@ -28,7 +28,9 @@ class TextCharacters(SceneData):
     def build_textures(self):
         # This doesn't check if the textures have already been built
         self.font.set_size(self.font_size, 200)
-        chars = [ord(_) for _ in string.printable]
+        # skip whitespace control characters (\t, \n, \r, \x0b, \x0c): fonts
+        # have no glyphs for them, so loading them warns and draws nothing
+        chars = [ord(_) for _ in string.printable if _ == " " or not _.isspace()]
         tex_ids = GL.glGenTextures(len(chars))
         vert = []
         for i, (tex_id, char_code) in enumerate(zip(tex_ids, chars)):


### PR DESCRIPTION
Fonts have no glyphs for \t, \n, \r, \x0b, \x0c, so loading them from string.printable emitted 'Glyph N missing from font(s)' warnings on every TextCharacters build. TextAnnotation now skips characters absent from the atlas instead of raising KeyError.