### PR TITLE
add image_test mark, skip-image-tests option to skip rendering-context tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -35,6 +35,12 @@ def pytest_addoption(parser):
         default=1024,
         help="default height of offscreen rendering canvases",
     )
+    parser.addoption(
+        "--skip-image-tests",
+        action="store_true",
+        default=False,
+        help="skip tests marked as image_test (they need a live rendering context)",
+    )
 
 
 def _resolve_backend(config):
@@ -54,6 +60,11 @@ def _resolve_backend(config):
 
 
 def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "image_test: test renders with a live rendering context "
+        "(deselect with --skip-image-tests)",
+    )
     # this will get run before all tests, before collection and
     # any opengl imports that happen within test files.
     config._offscreen_backend = _resolve_backend(config)
@@ -62,6 +73,15 @@ def pytest_configure(config):
         config.getoption("--canvas-height"),
     )
     prepare_platform(config._offscreen_backend)
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--skip-image-tests"):
+        return
+    skip_image = pytest.mark.skip(reason="--skip-image-tests was given")
+    for item in items:
+        if "image_test" in item.keywords:
+            item.add_marker(skip_image)
 
 
 def pytest_report_header(config):

--- a/yt_idv/tests/test_block_normalization.py
+++ b/yt_idv/tests/test_block_normalization.py
@@ -17,6 +17,7 @@ def ds_yt_ugrid():
     return ds
 
 
+@pytest.mark.image_test
 def test_block_collection_normalization(empty_rc, ds_yt_ugrid):
 
     block_coll: BlockCollection = BlockCollection(
@@ -31,6 +32,7 @@ def test_block_collection_normalization(empty_rc, ds_yt_ugrid):
     assert np.allclose(block_coll.texture_objects[0].data, 0.5)
 
 
+@pytest.mark.image_test
 def test_block_rendering_cmap_norms(empty_rc, ds_yt_ugrid, image_store):
 
     block_coll: BlockCollection = BlockCollection(

--- a/yt_idv/tests/test_spherical_vol_rendering.py
+++ b/yt_idv/tests/test_spherical_vol_rendering.py
@@ -52,6 +52,7 @@ def _get_sph_yt_ds(bbox_option: str):
 
 
 @pytest.mark.parametrize("bbox_option", bbox_options.keys())
+@pytest.mark.image_test
 def test_spherical_bounds(empty_rc, image_store, bbox_option):
 
     ds = _get_sph_yt_ds(bbox_option)
@@ -69,6 +70,7 @@ def test_spherical_bounds(empty_rc, image_store, bbox_option):
 
 
 @pytest.mark.parametrize("nprocs", [1, 2, 4, 16])
+@pytest.mark.image_test
 def test_spherical_nprocs(empty_rc, image_store, nprocs):
 
     bbox_option = "whole"
@@ -88,6 +90,7 @@ def test_spherical_nprocs(empty_rc, image_store, nprocs):
 
 
 @pytest.mark.parametrize("bbox_option", ["partial", "big_r"])
+@pytest.mark.image_test
 def test_block_collection_outlines(empty_rc, image_store, bbox_option):
 
     ds = _get_sph_yt_ds(bbox_option)

--- a/yt_idv/tests/test_yt_idv.py
+++ b/yt_idv/tests/test_yt_idv.py
@@ -37,6 +37,7 @@ def empty_scene_rc(make_rc):
     return rc
 
 
+@pytest.mark.image_test
 def test_snapshots(fake_amr_rc, image_store):
     """Check that we can make some snapshots."""
     fake_amr_rc.scene.components[0].render_method = "max_intensity"
@@ -49,6 +50,7 @@ def test_snapshots(fake_amr_rc, image_store):
     image_store(fake_amr_rc)
 
 
+@pytest.mark.image_test
 def test_camera_position(fake_amr_rc, image_store):
     """Check that we can update the camera position"""
     vm = fake_amr_rc.scene.camera.view_matrix
@@ -58,11 +60,13 @@ def test_camera_position(fake_amr_rc, image_store):
     image_store(fake_amr_rc)
 
 
+@pytest.mark.image_test
 def test_depth_buffer_toggle(fake_amr_rc, image_store):
     fake_amr_rc.scene.components[0].use_db = True
     image_store(fake_amr_rc)
 
 
+@pytest.mark.image_test
 def test_slice(fake_amr_rc, image_store):
     fake_amr_rc.scene.components[0].render_method = "slice"
     fake_amr_rc.scene.components[0].slice_position = (0.5, 0.5, 0.5)
@@ -89,6 +93,7 @@ def _interior_gaps(image):
 
 
 @pytest.mark.parametrize("near_plane", [1e-4, 1e-2])
+@pytest.mark.image_test
 def test_slice_no_block_boundary_gaps(fake_amr_rc, near_plane):
     """Rays that hit a face shared by two blocks must be drawn by one of them."""
     component = fake_amr_rc.scene.components[0]
@@ -103,6 +108,7 @@ def test_slice_no_block_boundary_gaps(fake_amr_rc, near_plane):
     assert _interior_gaps(fake_amr_rc.run()).sum() == 0
 
 
+@pytest.mark.image_test
 def test_annotate_boxes(empty_scene_rc, image_store):
     """Check the box annotation."""
     empty_scene_rc.scene.add_box([0.0, 0.0, 0.0], [1.0, 1.0, 1.0])
@@ -114,6 +120,7 @@ def test_annotate_boxes(empty_scene_rc, image_store):
     image_store(empty_scene_rc)
 
 
+@pytest.mark.image_test
 def test_annotate_grids(empty_scene_rc, image_store):
     """Make sure we can add some grid positions."""
     from yt_idv.scene_annotations.grid_outlines import GridOutlines  # NOQA
@@ -130,6 +137,7 @@ def test_annotate_grids(empty_scene_rc, image_store):
     image_store(empty_scene_rc)
 
 
+@pytest.mark.image_test
 def test_annotate_text(empty_scene_rc, image_store):
     """Test that text can be annotated and updated."""
     text = empty_scene_rc.scene.add_text("Origin 0 0", origin=(0.0, 0.0))
@@ -147,11 +155,13 @@ def test_annotate_text(empty_scene_rc, image_store):
     image_store(empty_scene_rc)
 
 
+@pytest.mark.image_test
 def test_isocontour_functionality(fake_amr_rc, image_store):
     fake_amr_rc.scene.components[0].render_method = "isocontours"
     image_store(fake_amr_rc)
 
 
+@pytest.mark.image_test
 def test_curves(fake_amr_rc, image_store):
     # add a single curve
 
@@ -193,6 +203,7 @@ def set_very_bad_shader():
     known_shaders["vertex"]["default"]["source"] = good_shader
 
 
+@pytest.mark.image_test
 def test_bad_shader(empty_scene_rc, set_very_bad_shader):
     # this test is meant to check that a bad shader would indeed be caught
     # by the subsequent test_shader_programs test.
@@ -210,6 +221,7 @@ def test_bad_shader(empty_scene_rc, set_very_bad_shader):
 
 
 @pytest.mark.parametrize("shader_name", list(shader_objects.component_shaders.keys()))
+@pytest.mark.image_test
 def test_shader_programs(empty_scene_rc, shader_name):
     for program in shader_objects.component_shaders[shader_name].values():
 
@@ -243,6 +255,7 @@ def test_shader_programs(empty_scene_rc, shader_name):
         _ = shader_objects.ShaderProgram(colormap_vertex, colormap_fragment)
 
 
+@pytest.mark.image_test
 def test_camera_dict_update(fake_amr_rc):
     pos = [0.5, 2.0, 3.0]
     fake_amr_rc.scene.camera.set_position(pos)
@@ -255,6 +268,7 @@ def test_camera_dict_update(fake_amr_rc):
     assert_equal(fake_amr_rc.scene.camera.position, pos)
 
 
+@pytest.mark.image_test
 def test_block_collection_grid_ids(make_rc):
     rc = make_rc()
     ds = yt.testing.fake_amr_ds()
@@ -270,6 +284,7 @@ def test_block_collection_grid_ids(make_rc):
     assert len(grids) == len(gl)
 
 
+@pytest.mark.image_test
 def test_manual_scene_graph(make_rc, image_store):
     rc = make_rc()
     ds = yt.testing.fake_amr_ds()
@@ -283,6 +298,7 @@ def test_manual_scene_graph(make_rc, image_store):
     image_store(rc)
 
 
+@pytest.mark.image_test
 def test_block_collection_min_max(make_rc, image_store):
     rc = make_rc()
     ds = yt.testing.fake_amr_ds()


### PR DESCRIPTION
with all the test infrastructure updates, i thought it'd be nice to have an option for skipping tests that require a rendering context:

```
pytest --skip-image-tests
```

will now skip all those tests. 