### PR TITLE
add orthographic projection option to the camera, wire the shaders

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -98,6 +98,16 @@ data being rendered. The image plane extraction is currently supported for
 ``render_method`` of ``max_intensity``, ``slice`` and ``projection``. For the
 case of ``projection``, the data values are the path-integrated data values along
 ray paths and will be sensitive to the camera type (which determines ray path).
+With the default perspective camera the rays diverge from the camera position, so
+the integrals only approximate a yt projection; setting
+
+.. code-block:: python
+
+   rc.scene.camera.projection_type = "orthographic"
+
+before rendering casts parallel rays, so that the ``projection`` values integrate
+like a yt projection (note that particle and mesh components ignore
+``projection_type``: particle billboard sizing assumes a perspective projection).
 
 See :meth:`~yt_idv.scene_components.blocks.BlockRendering.rendered_image_plane` for
 more details.

--- a/yt_idv/cameras/base_camera.py
+++ b/yt_idv/cameras/base_camera.py
@@ -21,13 +21,20 @@ class BaseCamera(traitlets.HasTraits):
     up : :obj:`!iterable`, or 3 element array in code_length
         The 'up' direction for the camera.
     fov : float, optional
-        An angle defining field of view in degrees.
+        An angle defining field of view in degrees. For an orthographic
+        projection, this sets the half-height of the view volume to
+        tan(fov/2) * |position - focus|, matching the perspective frustum's
+        extent at the focal plane.
     near_plane : float, optional
         The distance to the near plane of the perspective camera.
     far_plane : float, optional
         The distance to the far plane of the perspective camera.
     aspect_ratio: float, optional
         The ratio between the height and the width of the camera's fov.
+    projection_type : str, optional
+        The projection used to map 3D space onto the image plane, either
+        "perspective" (default, rays diverge from the camera position) or
+        "orthographic" (parallel rays along the view direction).
 
     """
 
@@ -45,6 +52,9 @@ class BaseCamera(traitlets.HasTraits):
     aspect_ratio = traitlets.Float(
         1.0
     )  # This was 8.0/6.0 for a long time. I don't know why.
+    projection_type = traitlets.CaselessStrEnum(
+        ("perspective", "orthographic"), default_value="perspective"
+    )
 
     projection_matrix = traittypes.Array(np.zeros((4, 4))).valid(
         ndarray_shape(4, 4), ndarray_ro()
@@ -80,6 +90,7 @@ class BaseCamera(traitlets.HasTraits):
         "far_plane",
         "aspect_ratio",
         "orientation",
+        "projection_type",
     )
     def compute_matrices(self, change=None):
         """Regenerate all position, view and projection matrices of the camera."""
@@ -120,6 +131,12 @@ class BaseCamera(traitlets.HasTraits):
         shader_program._set_uniform("near_plane", self.near_plane)
         shader_program._set_uniform("far_plane", self.far_plane)
         shader_program._set_uniform("camera_pos", self.position)
+        view_dir = np.asarray(self.focus - self.position, dtype="f4")
+        view_dir = view_dir / np.linalg.norm(view_dir)
+        shader_program._set_uniform("camera_view_dir", view_dir)
+        shader_program._set_uniform(
+            "projection_type", int(self.projection_type == "orthographic")
+        )
 
     def dict(self):
         # array attributes
@@ -136,6 +153,7 @@ class BaseCamera(traitlets.HasTraits):
             "near_plane",
             "far_plane",
             "aspect_ratio",
+            "projection_type",
         ]
         for ky in attrs:
             cdict[ky] = getattr(self, ky)

--- a/yt_idv/cameras/trackball_camera.py
+++ b/yt_idv/cameras/trackball_camera.py
@@ -2,6 +2,7 @@ import numpy as np
 import traitlets
 from yt.utilities.math_utils import (
     get_lookat_matrix,
+    get_orthographic_matrix,
     get_perspective_matrix,
     quaternion_to_rotation_matrix,
     rotation_matrix_to_quaternion,
@@ -26,8 +27,29 @@ class TrackballCamera(BaseCamera):
     """
 
     @property
-    def proj_func(self):
-        return get_perspective_matrix
+    def orthographic_scale(self):
+        # half-height of the orthographic view volume, chosen to match the
+        # perspective frustum's half-height at the focal plane so that
+        # toggling projection_type preserves the apparent size at the focus
+        # (exact for aspect_ratio == 1) and moving the camera still zooms
+        return np.tan(np.radians(self.fov) / 2.0) * np.linalg.norm(
+            self.position - self.focus
+        )
+
+    def _get_projection_matrix(self):
+        if self.projection_type == "orthographic":
+            # get_orthographic_matrix uses the column-major (OpenGL) layout,
+            # the transpose of get_perspective_matrix; yt_idv computes
+            # projection @ view row-major and uploads with transpose=GL_TRUE
+            return get_orthographic_matrix(
+                self.orthographic_scale,
+                self.aspect_ratio,
+                self.near_plane,
+                self.far_plane,
+            ).T
+        return get_perspective_matrix(
+            self.fov, self.aspect_ratio, self.near_plane, self.far_plane
+        )
 
     @traitlets.default("orientation")
     def _orientation_default(self):
@@ -62,17 +84,13 @@ class TrackballCamera(BaseCamera):
 
         self.view_matrix = get_lookat_matrix(self.position, self.focus, self.up)
 
-        self.projection_matrix = self.proj_func(
-            self.fov, self.aspect_ratio, self.near_plane, self.far_plane
-        )
+        self.projection_matrix = self._get_projection_matrix()
 
     def _update_matrices(self):
         self.view_matrix = get_lookat_matrix(self.position, self.focus, self.up)
         self.orientation = rotation_matrix_to_quaternion(self.view_matrix[0:3, 0:3])
 
-        self.projection_matrix = self.proj_func(
-            self.fov, self.aspect_ratio, self.near_plane, self.far_plane
-        )
+        self.projection_matrix = self._get_projection_matrix()
 
     def move_forward(self, move_amount):
         dpos = (self.focus - self.position) / np.linalg.norm(self.focus - self.position)
@@ -83,6 +101,10 @@ class TrackballCamera(BaseCamera):
             dpos = np.array([0.0, 0.0, 0.0])
         self.position += dpos
         self.view_matrix = get_lookat_matrix(self.position, self.focus, self.up)
+        if self.projection_type == "orthographic":
+            # the orthographic scale depends on the camera-focus distance,
+            # so moving the camera zooms only if the projection is rebuilt
+            self.projection_matrix = self._get_projection_matrix()
 
     def _compute_matrices(self):
         pass

--- a/yt_idv/rendered_image_plane.py
+++ b/yt_idv/rendered_image_plane.py
@@ -89,9 +89,10 @@ def image_plane_extent(projection_matrix, view_matrix, focus):
     """
     The extent of the viewport in the plane that contains the camera focus.
 
-    Because the camera uses a perspective projection, the region of space that
-    the image covers depends on distance from the camera: this returns the
-    extent in the plane through ``focus`` that is normal to the view direction.
+    For a perspective projection, the region of space that the image covers
+    depends on distance from the camera; for an orthographic projection it is
+    the same in every plane. In both cases this returns the extent in the
+    plane through ``focus`` that is normal to the view direction.
 
     Parameters
     ----------

--- a/yt_idv/scene_components/blocks.py
+++ b/yt_idv/scene_components/blocks.py
@@ -208,6 +208,14 @@ class BlockRendering(SceneComponent):
         vertex-centered data used to build the 3D textures, so they can fall
         slightly outside the range of the cell-centered field (particularly with
         ``no_ghost=True``).
+
+        For ``projection``, values are path integrals along the rays cast by
+        the camera. With the default perspective camera the rays diverge, so
+        the integrals only approximate a yt projection; setting
+        ``camera.projection_type = "orthographic"`` before rendering casts
+        parallel rays, making them true parallel-ray path integrals (and
+        ``RenderedImagePlane.integrate`` then recovers the total up to
+        discretization error).
         """
         if self.first_pass_fb_rgba is None:
             raise RuntimeError(

--- a/yt_idv/shaders/isocontour.frag.glsl
+++ b/yt_idv/shaders/isocontour.frag.glsl
@@ -45,16 +45,34 @@ void main()
 
     // Five samples
     vec3 step_size = dx/sample_factor;
-    vec3 dir = -normalize(camera_pos.xyz - ray_position);
-    dir = max(abs(dir), 0.0001) * sign(dir);
+    vec3 ray_origin;
+    vec3 dir;
+    if (projection_type == 1) {
+        // orthographic: all rays are parallel to the view direction. the ray
+        // origin is the fragment's position on the block face slid back to
+        // the camera plane, so that t means "distance in front of the
+        // camera" exactly as in the perspective branch below -- regardless
+        // of whether face culling handed us the entry or the exit face
+        dir = camera_view_dir;
+        ray_origin = ray_position - dir * dot(ray_position - camera_pos.xyz, dir);
+    } else {
+        dir = -normalize(camera_pos.xyz - ray_position);
+        ray_origin = camera_pos.xyz;
+    }
+    // clamp components away from zero; sign(0.0) == 0.0 would leave them
+    // zero (idir = inf), and axis-aligned orthographic views make exact
+    // zeros the common case rather than a measure-zero event
+    vec3 dsign = sign(dir);
+    dsign += vec3(equal(dsign, vec3(0.0)));
+    dir = max(abs(dir), 0.0001) * dsign;
     vec4 curr_color = vec4(0.0);
 
     // We need to figure out where the ray intersects the box, if it intersects the box.
     // This will help solve the left/right edge issues.
 
     vec3 idir = 1.0/dir;
-    vec3 tl = (left_edge - camera_pos)*idir;
-    vec3 tr = (right_edge - camera_pos)*idir;
+    vec3 tl = (left_edge - ray_origin)*idir;
+    vec3 tr = (right_edge - ray_origin)*idir;
     vec3 tmin, tmax;
     bvec3 temp_x, temp_y;
     // These 't' prefixes actually mean 'parameter', as we use in grid_traversal.pyx.
@@ -73,8 +91,8 @@ void main()
     // Some more discussion of this here:
     //  http://prideout.net/blog/?p=64
 
-    vec3 p0 = camera_pos.xyz + dir * t0;
-    vec3 p1 = camera_pos.xyz + dir * t1;
+    vec3 p0 = ray_origin + dir * t0;
+    vec3 p1 = ray_origin + dir * t1;
 
     vec3 dxidir = abs(idir)  * step_size;
 

--- a/yt_idv/shaders/known_uniforms.inc.glsl
+++ b/yt_idv/shaders/known_uniforms.inc.glsl
@@ -39,6 +39,8 @@ uniform vec4 viewport; // (offset_x, offset_y, 1 / screen_x, 1 / screen_y)
 uniform mat4 inv_pmvm;
 uniform float near_plane;
 uniform float far_plane;
+uniform vec3 camera_view_dir; // normalize(focus - position)
+uniform int projection_type;  // 0 = perspective (default), 1 = orthographic
 
 // textures we tend to use
 uniform sampler1D cm_tex;

--- a/yt_idv/shaders/ray_tracing.frag.glsl
+++ b/yt_idv/shaders/ray_tracing.frag.glsl
@@ -62,8 +62,26 @@ void main()
     output_color = vec4(0.);
 
     // Five samples
-    vec3 dir = -normalize(camera_pos.xyz - ray_position);
-    dir = max(abs(dir), 0.0001) * sign(dir);
+    vec3 ray_origin;
+    vec3 dir;
+    if (projection_type == 1) {
+        // orthographic: all rays are parallel to the view direction. the ray
+        // origin is the fragment's position on the block face slid back to
+        // the camera plane, so that t means "distance in front of the
+        // camera" exactly as in the perspective branch below -- regardless
+        // of whether face culling handed us the entry or the exit face
+        dir = camera_view_dir;
+        ray_origin = ray_position - dir * dot(ray_position - camera_pos.xyz, dir);
+    } else {
+        dir = -normalize(camera_pos.xyz - ray_position);
+        ray_origin = camera_pos.xyz;
+    }
+    // clamp components away from zero; sign(0.0) == 0.0 would leave them
+    // zero (idir = inf), and axis-aligned orthographic views make exact
+    // zeros the common case rather than a measure-zero event
+    vec3 dsign = sign(dir);
+    dsign += vec3(equal(dsign, vec3(0.0)));
+    dir = max(abs(dir), 0.0001) * dsign;
     vec4 curr_color = vec4(0.0);
 
     // We need to figure out where the ray intersects the box, if it intersects the box.
@@ -73,12 +91,12 @@ void main()
     vec3 tl, tr;
     vec3 dx_effective;
     #ifdef NONCARTESIAN_GEOM
-    tl = (left_edge_cart - camera_pos)*idir;
-    tr = (right_edge_cart - camera_pos)*idir;
+    tl = (left_edge_cart - ray_origin)*idir;
+    tr = (right_edge_cart - ray_origin)*idir;
     dx_effective = dx_cart;
     #else
-    tl = (left_edge - camera_pos)*idir;
-    tr = (right_edge - camera_pos)*idir;
+    tl = (left_edge - ray_origin)*idir;
+    tr = (right_edge - ray_origin)*idir;
     dx_effective = dx;
     #endif
     vec3 step_size = dx_effective/ sample_factor;
@@ -101,8 +119,8 @@ void main()
     // Some more discussion of this here:
     //  http://prideout.net/blog/?p=64
 
-    vec3 p0 = camera_pos.xyz + dir * t0;
-    vec3 p1 = camera_pos.xyz + dir * t1;
+    vec3 p0 = ray_origin + dir * t0;
+    vec3 p1 = ray_origin + dir * t1;
 
     vec3 dxidir = abs(idir)  * step_size;
 

--- a/yt_idv/shaders/slice_sample.frag.glsl
+++ b/yt_idv/shaders/slice_sample.frag.glsl
@@ -25,7 +25,11 @@ void main()
     // blocks disagree about where a ray crosses the face they share.
     vec3 ray_position = v_model.xyz;
 
-    vec3 dir = normalize(camera_pos.xyz - ray_position);
+    // note: dir points toward the camera here, hence -camera_view_dir for
+    // the parallel rays of an orthographic projection
+    vec3 dir = (projection_type == 1)
+        ? -camera_view_dir
+        : normalize(camera_pos.xyz - ray_position);
     vec4 curr_color = vec4(0.0);
 
     // We'll compute the t at which this ray intersects the slice. If that t

--- a/yt_idv/simple_gui.py
+++ b/yt_idv/simple_gui.py
@@ -138,6 +138,14 @@ class SimpleGUI:
             if _:
                 scene.camera.near_plane = values[0]
                 scene.camera.far_plane = values[1]
+            _, ortho = imgui.checkbox(
+                "Orthographic", scene.camera.projection_type == "orthographic"
+            )
+            changed = changed or _
+            if _:
+                scene.camera.projection_type = (
+                    "orthographic" if ortho else "perspective"
+                )
             if imgui.button("Center"):
                 scene.camera.position = np.array([0.499, 0.499, 0.499])
                 scene.camera.focus = np.array([0.5, 0.5, 0.5])

--- a/yt_idv/tests/test_camera.py
+++ b/yt_idv/tests/test_camera.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from yt_idv.cameras.trackball_camera import TrackballCamera
+
+
+def _get_camera(projection_type: str) -> TrackballCamera:
+    cam = TrackballCamera(
+        position=np.array([0.5, 0.5, 2.5]),
+        focus=np.array([0.5, 0.5, 0.5]),
+        up=np.array([0.0, 1.0, 0.0]),
+        projection_type=projection_type,
+    )
+    cam._update_matrices()
+    return cam
+
+
+def _to_ndc(cam: TrackballCamera, point: np.ndarray) -> np.ndarray:
+    clip = cam.projection_matrix @ cam.view_matrix @ np.append(point, 1.0)
+    return clip[:3] / clip[3]
+
+
+def test_orthographic_matrix_is_affine():
+    cam = _get_camera("orthographic")
+    proj = cam.projection_matrix
+    # no perspective divide: w must not depend on position
+    assert proj[3, 0] == proj[3, 1] == proj[3, 2] == 0.0
+    assert proj[3, 3] == 1.0
+    ndc_focus = _to_ndc(cam, cam.focus)
+    assert_allclose(ndc_focus[:2], 0.0, atol=1e-7)
+
+
+@pytest.mark.parametrize("projection_type", ["perspective", "orthographic"])
+def test_apparent_size_at_focal_plane(projection_type: str):
+    # at aspect_ratio == 1, a point one orthographic_scale above the focus
+    # lands on the top edge of the image in both projection modes, so
+    # toggling projection_type preserves apparent size at the focal plane
+    cam = _get_camera(projection_type)
+    point = cam.focus + cam.orthographic_scale * np.array([0.0, 1.0, 0.0])
+    ndc = _to_ndc(cam, point)
+    assert_allclose(ndc[1], 1.0, rtol=1e-6)
+    assert_allclose(ndc[0], 0.0, atol=1e-7)
+
+
+def test_dict_round_trip():
+    cam = _get_camera("orthographic")
+    cdict = cam.dict()
+    assert cdict["projection_type"] == "orthographic"
+
+    cam2 = TrackballCamera()
+    cam2.update(**cdict)
+    cam2._update_matrices()
+    assert_allclose(cam2.projection_matrix, cam.projection_matrix)
+    assert_allclose(cam2.view_matrix, cam.view_matrix)
+
+
+def test_orthographic_zoom_rescales_projection():
+    cam = _get_camera("orthographic")
+    scale0 = cam.projection_matrix[0, 0]
+    pos0 = cam.position.copy()
+    cam.move_forward(0.5)
+    assert not np.allclose(cam.position, pos0)
+    # moving toward the focus shrinks the view volume (zooms in)
+    assert cam.projection_matrix[0, 0] > scale0

--- a/yt_idv/tests/test_rendered_image_plane.py
+++ b/yt_idv/tests/test_rendered_image_plane.py
@@ -152,7 +152,8 @@ def test_projection_path_length_and_units(uniform_rc):
     assert_allclose(mean_along_ray[center].d, 1.5, atol=0.1)
 
 
-def test_frb_geometry(uniform_rc):
+@pytest.mark.parametrize("projection_type", ["perspective", "orthographic"])
+def test_frb_geometry(uniform_rc, projection_type):
     component = uniform_rc.scene.components[0]
     component.render_method = "slice"
 
@@ -160,13 +161,15 @@ def test_frb_geometry(uniform_rc):
     camera.update(position=[0.5, 0.5, 2.5], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
     camera.fov = 45.0
     camera.aspect_ratio = 1.0
+    camera.projection_type = projection_type
     camera._update_matrices()
     uniform_rc.scene.render()
 
     frb = component.rendered_image_plane()
 
     # for a symmetric frustum the visible extent at the focus plane is
-    # 2 * distance * tan(fov / 2)
+    # 2 * distance * tan(fov / 2); the orthographic view volume is sized to
+    # match it, so the expected extent is the same in both modes
     distance = 2.0
     expected = 2 * distance * np.tan(np.radians(45.0) / 2)
     assert_allclose(frb.width.d, expected, rtol=1e-5)
@@ -242,6 +245,67 @@ def test_integrate_constant(constant_rc):
     assert_allclose(integral.to("g").d, 1.0, rtol=rtol)
 
 
+def test_integrate_constant_orthographic(constant_rc):
+    component = constant_rc.scene.components[0]
+    component.render_method = "projection"
+
+    # with parallel rays there is no need for the far-away narrow-fov setup of
+    # test_integrate_constant: a normal camera distance and fov suffice
+    camera = constant_rc.scene.camera
+    camera.update(position=[0.5, 0.5, 2.5], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
+    camera.fov = 45.0
+    camera.aspect_ratio = 1.0
+    camera.projection_type = "orthographic"
+    camera._update_matrices()
+    component.sample_factor = 8.0
+    constant_rc.scene.render()
+
+    frb = component.rendered_image_plane()
+    dx, dy = frb.pixel_size
+
+    # the whole cube has to be inside the image, or the integral would clip it
+    assert frb.width.d > 1.0 and frb.height.d > 1.0
+
+    integral = frb.integrate()
+    assert integral.units.dimensions == Unit("g").dimensions
+
+    # a 1 m cube at a constant 1 g/m**3 holds 1 g. the rays are truly parallel,
+    # so unlike the perspective case there is no fov-divergence error term:
+    # only the pixelization of the silhouette and the exit overshoot remain.
+    # each ray crosses two blocks of the 2x2x2 decomposition along the view
+    # axis and overshoots each block's exit by up to one step
+    rtol = 2 * max(dx.d, dy.d) + 2.0 / (32 * component.sample_factor)
+    assert_allclose(integral.to("g").d, 1.0, rtol=rtol)
+
+
+def test_orthographic_path_length_is_uniform(uniform_rc):
+    component = uniform_rc.scene.components[0]
+    component.render_method = "projection"
+
+    camera = uniform_rc.scene.camera
+    camera.update(position=[0.5, 0.5, 2.5], focus=[0.5, 0.5, 0.5], up=[0.0, 1.0, 0.0])
+    camera.fov = 45.0
+    camera.aspect_ratio = 1.0
+    camera.projection_type = "orthographic"
+    camera._update_matrices()
+    component.sample_factor = 8.0
+    uniform_rc.scene.render()
+
+    frb = component.rendered_image_plane()
+    ny, nx = frb.data.shape
+    center = (ny // 2, nx // 2)
+
+    # each parallel axis-aligned ray crosses the full unit depth of the domain
+    # exactly once, overshooting the exit by at most one step
+    step = 1.0 / (32 * component.sample_factor)
+    assert_allclose(frb.path_length[center].d, 1.0, atol=1.5 * step)
+
+    # and, unlike perspective rays through the image corners, every sampled
+    # ray has the same path length
+    sampled = frb.path_length.d > 0.5
+    assert_allclose(frb.path_length.d[sampled], 1.0, atol=1.5 * step)
+
+
 def test_projection_marches_each_ray_once(constant_rc):
     # every pixel within the silhouette of a block is covered by two faces of
     # the cube the geometry shader emits, and the projection shader blends
@@ -263,14 +327,24 @@ def test_projection_marches_each_ray_once(constant_rc):
 
 
 def test_image_plane_extent_round_trip():
-    from yt.utilities.math_utils import get_lookat_matrix, get_perspective_matrix
+    from yt.utilities.math_utils import (
+        get_lookat_matrix,
+        get_orthographic_matrix,
+        get_perspective_matrix,
+    )
 
     focus = np.array([0.5, 0.5, 0.5])
     position = np.array([1.0, 2.0, 3.0])
     view_matrix = get_lookat_matrix(position, focus, np.array([0.0, 1.0, 0.0]))
 
+    projection_matrices = []
     for aspect in (1.0, 1.6):
-        projection_matrix = get_perspective_matrix(45.0, aspect, 0.001, 20.0)
+        projection_matrices.append(get_perspective_matrix(45.0, aspect, 0.001, 20.0))
+        # get_orthographic_matrix is column-major; transpose to the row-major
+        # convention yt_idv uses (as TrackballCamera._get_projection_matrix does)
+        projection_matrices.append(get_orthographic_matrix(2.0, aspect, 0.001, 20.0).T)
+
+    for projection_matrix in projection_matrices:
         extent, right, up = image_plane_extent(projection_matrix, view_matrix, focus)
 
         # the corners of the extent must map back to the corners of the


### PR DESCRIPTION
In testing the spherical volume rendering with the new rendered_image_plane, due to the perspective camera and projection I had to do a lot of fiddling with field of view to check that the resulting projections can return expected integrations. Then realized that we could just support orthographic projections ... 

Implementation here is Claude's: the main difference at the shader level is just that in the fragment shaders the view direction is fixed by the camera, so we needed to pass down some uniforms to use for that. On the camera side, we're using yt's `get_orthographic_matrix` for the view matrix and tying the zoom control to field of view so that zooming blows up the image (without this, changing the camera position does nothing). and it's wired all the way up to the gui, so you can switch between orthographic and perspective cameras. 